### PR TITLE
feat(backend): add cards_management functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON := python3
 
 lint:
 	@echo "Linting..."
-	@${PYTHON} -m flake8 lento
+	@${PYTHON} -m flake8 lento tests
 	@echo "Done!"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ PYTHON := python3
 .PHONY = lint test run build_macos build_windows remove-build-files
 
 lint:
-	@echo "Linting..."
+	@echo Linting...
 	@${PYTHON} -m flake8 lento tests --exclude="tests/helpers.py"
-	@echo "Done!"
+	@echo Done!
 
 test:
-	@echo "Testing..."
+	@echo Testing...
 	@${PYTHON} -m pytest tests
-	@echo "Done!"
+	@echo Done!
 
 run: test lint
 	@${PYTHON} app.py

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ test:
 	@${PYTHON} -m pytest tests
 	@echo Done!
 
+vtest:
+	@echo Testing...
+	@${PYTHON} -m pytest -vv tests
+	@echo Done!
+
 run: test lint
 	@${PYTHON} app.py
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON := python3
 
 lint:
 	@echo "Linting..."
-	@${PYTHON} -m flake8 lento tests
+	@${PYTHON} -m flake8 lento tests --exclude="tests/helpers.py"
 	@echo "Done!"
 
 test:

--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,7 @@
 # CONSEQUENCES.
 import argparse
 import copy
+import json
 import os
 import platform
 from lento.common import cards_management as CardsManagement
@@ -53,19 +54,18 @@ if f == "create_card":
     CardsManagement.create_card()
     result_options["output"] = CardsManagement.read_cards()
 elif f == "read_cards":
-    r = CardsManagement.read_cards()
-    result_options["output"] = r
+    result_options["output"] = CardsManagement.read_cards()
 elif f == "delete_card":
-    r = CardsManagement.delete_card(param1)
+    CardsManagement.delete_card(param1)
     result_options["output"] = CardsManagement.read_cards()
 elif f == "update_metadata":
-    r = CardsManagement.update_metadata(param1, param2, param3)
+    CardsManagement.update_metadata(param1, param2, param3)
     result_options["output"] = CardsManagement.read_cards()
 elif f == "add_to_site_blocklists":
-    r = CardsManagement.add_to_site_blocklists(param1, param2, param3)
+    CardsManagement.add_to_site_blocklists(param1, param2, param3)
     result_options["output"] = CardsManagement.read_cards()
 elif f == "update_site_blocklists":
-    r = CardsManagement.update_site_blocklists(
+    CardsManagement.update_site_blocklists(
         param1,
         param2,
         {
@@ -92,14 +92,14 @@ elif f == "add_to_app_blocklists":
             "Lento",
             "vivaldi.bmp"
         )
-        r = CardsManagement.add_to_app_blocklists(
+        CardsManagement.add_to_app_blocklists(
             param1,
             param2,
             apps_to_add
         )
         result_options["output"] = CardsManagement.read_cards()
     elif platform.system() == "Darwin":
-        r = CardsManagement.add_to_app_blocklists(
+        CardsManagement.add_to_app_blocklists(
             param1,
             param2,
             [
@@ -113,13 +113,47 @@ elif f == "get_apps":
     r = utils.get_apps()
     result_options["output"] = r
 elif f == "update_app_blocklists":
-    r = CardsManagement.update_app_blocklists(
-        param1,
-        param2,
-        param3,
-    )
+    if platform.system() == "Windows":
+        CardsManagement.update_app_blocklists(
+            param1,
+            param2,
+            {
+                "vivaldi": {
+                    "enabled": True,
+                    "path": "C:\\Users\\natha\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",  # noqa: E501
+                    "app_icon_path": "C:\\Users\\natha\\AppData\\Local\\Lento\\vivaldi.bmp"  # noqa: E501
+                },
+                "Trello": {
+                    "enabled": False,
+                    "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",  # noqa: E501
+                    "app_icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"  # noqa: E501
+                }
+            }
+        )
+    elif platform.system() == "Darwin":
+        CardsManagement.update_app_blocklists(
+            param1,
+            param2,
+            {
+                "Scrivener": {
+                    "enabled": True,
+                    "bundle_id": "com.literatureandlatte.scrivener3",
+                    "app_icon_path": "~/Library/Application Support/Lento/Scrivener.jpg"  # noqa: E501
+                },
+                "NetNewsWire": {
+                    "enabled": True,
+                    "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
+                    "app_icon_path": "~/Library/Application Support/Lento/NetNewsWire.jpg"  # noqa: E501
+                },
+                "GRIS": {
+                    "enabled": True,
+                    "bundle_id": "unity.nomada studio.GRIS",
+                    "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"  # noqa: E501
+                },
+            }
+        )
 elif f == "add_notification":
-    r = CardsManagement.add_notification(
+    CardsManagement.add_notification(
         param1,
         param2,
         param3,
@@ -132,18 +166,18 @@ elif f == "add_notification":
         param10,
     )
 elif f == "update_notification_list":
-    r = CardsManagement.update_notification_list(
+    CardsManagement.update_notification_list(
         param1,
         param2,
     )
 elif f == "add_goal":
-    r = CardsManagement.add_goal(param1, param2)
+    CardsManagement.add_goal(param1, param2)
 elif f == "update_goal_list":
-    r = CardsManagement.update_goal_list(param1, param2)
+    CardsManagement.update_goal_list(param1, param2)
 else:
     result_options["message"] = f"INVALID COMMAND: {f}"
 
 print(result_options["message"])
 if result_options["output"] is not None:
     print("OUTPUT:")
-    print(result_options["output"])
+    print(json.dumps(result_options["output"], indent=4))

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@
 # IT WITH LENTO MAY HAVE UNINTENDED OR UNEXPECTED
 # CONSEQUENCES.
 import argparse
-from lento.common import cards_management
+from lento.common import cards_management as CardsManagement
 from lento import utils
 
 parser = argparse.ArgumentParser(
@@ -16,31 +16,29 @@ parser.add_argument(
     type=str,
     help="name of function to run"
 )
-parser.add_argument(
-    "param1",
-    nargs='?',
-    const='arg_was_not_given',
-    help='param for function to run'
-)
-parser.add_argument(
-    "param2",
-    nargs='?',
-    const='arg_was_not_given',
-    help='param for function to run'
-)
-parser.add_argument(
-    "param3",
-    nargs='?',
-    const='arg_was_not_given',
-    help='param for function to run'
-)
-
+parser.add_argument("param1", nargs='?')
+parser.add_argument("param2", nargs='?')
+parser.add_argument("param3", nargs='?')
+parser.add_argument("param4", nargs='?')
+parser.add_argument("param5", nargs='?')
+parser.add_argument("param6", nargs='?')
+parser.add_argument("param7", nargs='?')
+parser.add_argument("param8", nargs='?')
+parser.add_argument("param9", nargs='?')
+parser.add_argument("param10", nargs='?')
 
 args = parser.parse_args()
 f = args.name
-param = args.param1
+param1 = args.param1
 param2 = args.param2
 param3 = args.param3
+param4 = args.param4
+param5 = args.param5
+param6 = args.param6
+param7 = args.param7
+param8 = args.param8
+param9 = args.param9
+param10 = args.param10
 
 result_options = {
     "message": f"ran {f} successfully!",
@@ -48,29 +46,57 @@ result_options = {
 }
 
 if f == "create_card":
-    cards_management.create_card()
-    result_options["output"] = cards_management.read_cards()
+    CardsManagement.create_card()
+    result_options["output"] = CardsManagement.read_cards()
 elif f == "read_cards":
-    r = cards_management.read_cards()
+    r = CardsManagement.read_cards()
     result_options["output"] = r
 elif f == "delete_card":
-    r = cards_management.delete_card(param)
-    result_options["output"] = cards_management.read_cards()
+    r = CardsManagement.delete_card(param1)
+    result_options["output"] = CardsManagement.read_cards()
 elif f == "update_metadata":
-    r = cards_management.update_metadata(param, param2, param3)
-    result_options["output"] = cards_management.read_cards()
-elif f == "update_site_blocklist":
-    r = cards_management.update_site_blocklists(param, param2, param3)
-    result_options["output"] = cards_management.read_cards()
+    r = CardsManagement.update_metadata(param1, param2, param3)
+    result_options["output"] = CardsManagement.read_cards()
+elif f == "add_to_site_blocklists":
+    r = CardsManagement.add_to_site_blocklists(param1, param2, param3)
+    result_options["output"] = CardsManagement.read_cards()
 elif f == "add_to_app_blocklists":
-    r = cards_management.add_to_app_blocklists(
-        param,
+    r = CardsManagement.add_to_app_blocklists(
+        param1,
         param2,
         param3.split(",")
     )
-    result_options["output"] = cards_management.read_cards()
+    result_options["output"] = CardsManagement.read_cards()
 elif f == "get_apps":
     r = utils.get_apps()
+elif f == "update_app_blocklists":
+    r = CardsManagement.update_app_blocklists(
+        param1,
+        param2,
+        param3,
+    )
+elif f == "add_notification":
+    r = CardsManagement.add_notification(
+        param1,
+        param2,
+        param3,
+        param4,
+        param5,
+        param6,
+        param7,
+        param8,
+        param9,
+        param10,
+    )
+elif f == "update_notification_list":
+    r = CardsManagement.update_notification_list(
+        param1,
+        param2,
+    )
+elif f == "add_goal":
+    r = CardsManagement.add_goal(param1, param2)
+elif f == "update_goal_list":
+    r = CardsManagement.update_goal_list(param1, param2)
 else:
     result_options["message"] = f"INVALID COMMAND: {f}"
 

--- a/cli.py
+++ b/cli.py
@@ -1,13 +1,16 @@
 # THIS LENTO CLI IS FOR DEVELOPER USE ONLY. DO NOT
 # ATTEMPT TO USE THIS FOR SCRIPTING PURPOSES. END-USER
-# USE OF THIS SCRIPT IS NOT SUPPORTED. WE USE THIS 
+# USE OF THIS SCRIPT IS NOT SUPPORTED. WE USE THIS
 # SCRIPT FOR LIVE-AMMO TESTING OF THE BACKEND; USING
 # IT WITH LENTO MAY HAVE UNINTENDED OR UNEXPECTED
 # CONSEQUENCES.
 import argparse
-import json
+import copy
+import os
+import platform
 from lento.common import cards_management as CardsManagement
 from lento import utils
+from tests import helpers
 
 parser = argparse.ArgumentParser(
     description="Run backend functions to make sure they work."
@@ -65,18 +68,50 @@ elif f == "update_site_blocklists":
     r = CardsManagement.update_site_blocklists(
         param1,
         param2,
-        json.loads(param3)
+        {
+            "youtube.com": True,
+            "twitter.com": False
+        }
     )
     result_options["output"] = CardsManagement.read_cards()
 elif f == "add_to_app_blocklists":
-    r = CardsManagement.add_to_app_blocklists(
-        param1,
-        param2,
-        param3.split(",")
-    )
-    result_options["output"] = CardsManagement.read_cards()
+    if platform.system() == "Windows":
+        apps_to_add = copy.deepcopy(helpers.data["apps_to_add"])
+        apps_to_add[1]["path"] = os.path.join(
+            os.path.expanduser("~"),
+            "AppData",
+            "Local",
+            "Vivaldi",
+            "Application",
+            "vivaldi.exe"
+        )
+        apps_to_add[1]["icon_path"] = os.path.join(
+            os.path.expanduser("~"),
+            "AppData",
+            "Local",
+            "Lento",
+            "vivaldi.bmp"
+        )
+        r = CardsManagement.add_to_app_blocklists(
+            param1,
+            param2,
+            apps_to_add
+        )
+        result_options["output"] = CardsManagement.read_cards()
+    elif platform.system() == "Darwin":
+        r = CardsManagement.add_to_app_blocklists(
+            param1,
+            param2,
+            [
+                "/Applications/GRIS.app",
+                "/Applications/Scrivener.app",
+                "/Applications/NetNewsWire.app"
+            ]
+        )
+        result_options["output"] = CardsManagement.read_cards()
 elif f == "get_apps":
     r = utils.get_apps()
+    result_options["output"] = r
 elif f == "update_app_blocklists":
     r = CardsManagement.update_app_blocklists(
         param1,

--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,9 @@
+# THIS LENTO CLI IS FOR DEVELOPER USE ONLY. DO NOT
+# ATTEMPT TO USE THIS FOR SCRIPTING PURPOSES. END-USER
+# USE OF THIS SCRIPT IS NOT SUPPORTED. WE USE THIS 
+# SCRIPT FOR LIVE-AMMO TESTING OF THE BACKEND; USING
+# IT WITH LENTO MAY HAVE UNINTENDED OR UNEXPECTED
+# CONSEQUENCES.
 import argparse
 from lento.common import cards_management
 
@@ -15,11 +21,25 @@ parser.add_argument(
     const='arg_was_not_given',
     help='param for function to run'
 )
+parser.add_argument(
+    "param2",
+    nargs='?',
+    const='arg_was_not_given',
+    help='param for function to run'
+)
+parser.add_argument(
+    "param3",
+    nargs='?',
+    const='arg_was_not_given',
+    help='param for function to run'
+)
 
 
 args = parser.parse_args()
 f = args.name
 param = args.param1
+param2 = args.param2
+param3 = args.param3
 
 result_options = {
     "message": f"ran {f} successfully!",
@@ -28,11 +48,18 @@ result_options = {
 
 if f == "create_card":
     cards_management.create_card()
+    result_options["output"] = cards_management.read_cards()
 elif f == "read_cards":
     r = cards_management.read_cards()
     result_options["output"] = r
 elif f == "delete_card":
     r = cards_management.delete_card(param)
+    result_options["output"] = cards_management.read_cards()
+elif f == "update_metadata":
+    r = cards_management.update_metadata(param, param2, param3)
+    result_options["output"] = cards_management.read_cards()
+elif f == "update_site_blocklist":
+    r = cards_management.update_site_blocklists(param, param2, param3)
     result_options["output"] = cards_management.read_cards()
 else:
     result_options["message"] = f"INVALID COMMAND: {f}"

--- a/cli.py
+++ b/cli.py
@@ -155,25 +155,70 @@ elif f == "update_app_blocklists":
 elif f == "add_notification":
     CardsManagement.add_notification(
         param1,
+        True,
         param2,
-        param3,
-        param4,
-        param5,
-        param6,
-        param7,
-        param8,
-        param9,
-        param10,
+        "banner",
+        ["twitter.com", "youtube.com"],
+        ["Debug USACO problem"],
+        42,
+        "get back to work",
+        "keep focused",
+        {
+            "reminder": "~/Desktop/reminder.mp3",
+            "Frog": "/System/Library/Sounds/Frog.aiff"
+        }
     )
 elif f == "update_notification_list":
     CardsManagement.update_notification_list(
         param1,
-        param2,
+        {
+            "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+                "name": "testnotif2",
+                "enabled": True,
+                "type": "banner",
+                "blocked_visit_triggers": [
+                    "twitter.com",
+                    "youtube.com"
+                ],
+                "associated_goals": [
+                    "Debug USACO problem"
+                ],
+                "time_interval_trigger": 42,
+                "title": "get back to work",
+                "body": "keep focused",
+                "audio_paths": {
+                    "reminder": "~/Desktop/reminder.mp3",
+                    "Frog": "/System/Library/Sounds/Frog.aiff"
+                }
+            },
+            "ba606651f167406ca7cd88a8c9b05ceb": {
+                "name": "testnotif1",
+                "enabled": True,
+                "type": "banner",
+                "blocked_visit_triggers": [
+                    "twitter.com",
+                    "youtube.com"
+                ],
+                "associated_goals": [
+                    "Debug USACO problem"
+                ],
+                "time_interval_trigger": 42,
+                "title": "get back to work",
+                "body": "keep focused",
+                "audio_paths": {
+                    "reminder": "~/Desktop/reminder.mp3",
+                    "Frog": "/System/Library/Sounds/Frog.aiff"
+                }
+            }
+        },
     )
 elif f == "add_goal":
     CardsManagement.add_goal(param1, param2)
 elif f == "update_goal_list":
-    CardsManagement.update_goal_list(param1, param2)
+    CardsManagement.update_goal_list(param1, {
+        "Conquer world": True,
+        "Debug USACO problem": False,
+    })
 else:
     result_options["message"] = f"INVALID COMMAND: {f}"
 

--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,7 @@
 # CONSEQUENCES.
 import argparse
 from lento.common import cards_management
+from lento import utils
 
 parser = argparse.ArgumentParser(
     description="Run backend functions to make sure they work."
@@ -61,6 +62,8 @@ elif f == "update_metadata":
 elif f == "update_site_blocklist":
     r = cards_management.update_site_blocklists(param, param2, param3)
     result_options["output"] = cards_management.read_cards()
+elif f == "get_apps":
+    r = utils.get_apps()
 else:
     result_options["message"] = f"INVALID COMMAND: {f}"
 

--- a/cli.py
+++ b/cli.py
@@ -62,6 +62,13 @@ elif f == "update_metadata":
 elif f == "update_site_blocklist":
     r = cards_management.update_site_blocklists(param, param2, param3)
     result_options["output"] = cards_management.read_cards()
+elif f == "add_to_app_blocklists":
+    r = cards_management.add_to_app_blocklists(
+        param,
+        param2,
+        param3.split(",")
+    )
+    result_options["output"] = cards_management.read_cards()
 elif f == "get_apps":
     r = utils.get_apps()
 else:

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,20 @@
+import argparse
+from lento.common import cards_management
+
+parser = argparse.ArgumentParser(
+    description="Run backend functions to make sure they work."
+)
+parser.add_argument(
+    "name",
+    type=str,
+    help="name of function to run"
+)
+
+args = parser.parse_args()
+f = args.name
+
+if f == "create_card":
+    cards_management.create_card()
+    print("ran create_card successfully!")
+else:
+    print(f"INVALID COMMAND: {f}")

--- a/cli.py
+++ b/cli.py
@@ -9,12 +9,35 @@ parser.add_argument(
     type=str,
     help="name of function to run"
 )
+parser.add_argument(
+    "param1",
+    nargs='?',
+    const='arg_was_not_given',
+    help='param for function to run'
+)
+
 
 args = parser.parse_args()
 f = args.name
+param = args.param1
+
+result_options = {
+    "message": f"ran {f} successfully!",
+    "output": None,
+}
 
 if f == "create_card":
     cards_management.create_card()
-    print("ran create_card successfully!")
+elif f == "read_cards":
+    r = cards_management.read_cards()
+    result_options["output"] = r
+elif f == "delete_card":
+    r = cards_management.delete_card(param)
+    result_options["output"] = cards_management.read_cards()
 else:
-    print(f"INVALID COMMAND: {f}")
+    result_options["message"] = f"INVALID COMMAND: {f}"
+
+print(result_options["message"])
+if result_options["output"] is not None:
+    print("OUTPUT:")
+    print(result_options["output"])

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@
 # IT WITH LENTO MAY HAVE UNINTENDED OR UNEXPECTED
 # CONSEQUENCES.
 import argparse
+import json
 from lento.common import cards_management as CardsManagement
 from lento import utils
 
@@ -59,6 +60,13 @@ elif f == "update_metadata":
     result_options["output"] = CardsManagement.read_cards()
 elif f == "add_to_site_blocklists":
     r = CardsManagement.add_to_site_blocklists(param1, param2, param3)
+    result_options["output"] = CardsManagement.read_cards()
+elif f == "update_site_blocklists":
+    r = CardsManagement.update_site_blocklists(
+        param1,
+        param2,
+        json.loads(param3)
+    )
     result_options["output"] = CardsManagement.read_cards()
 elif f == "add_to_app_blocklists":
     r = CardsManagement.add_to_app_blocklists(

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -14,12 +14,28 @@
                 "youtube.com": true
             },
             "hard_blocked_apps": {
-                "GRIS": true,
-                "Into the Breach": true
+                "GRIS": {
+                    "enabled": true,
+                    "bundle_id": "unity.nomada studio.GRIS",
+                    "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"
+                },
+                "Into the Breach": {
+                    "enabled": true,
+                    "bundle_id": "subset.Into-the-Breach",
+                    "app_icon_path": "~/Library/Application Support/Lento/Into the Breach.jpg"
+                }
             },
             "soft_blocked_apps": {
-                "NetNewsWire": true,
-                "calibre": false
+                "NetNewsWire": {
+                    "enabled": true,
+                    "bundle_id": "com.ranchero.NetNewsWire-Evergreen"
+                    "app_icon_path": "~/Library/Application Support/Lento/NetNewsWire.jpg"
+                },
+                "calibre": {
+                    "enabled": false,
+                    "bundle_id": "net.kovidgoyal.calibre"
+                    "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
+                }
             },
             "notifications": {
                 "a019868e-f43f-478f-8dcc-ba78c35525c4": {

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -48,7 +48,8 @@
                         "Debug USACO problem"
                     ],
                     "time_interval_trigger": null,
-                    "text": "Get back to %g!",
+                    "title": "Get back to %g!",
+                    "body": "Keep focused!",
                     "audio_paths": {
                         "reminder": "~/Desktop/reminder.mp3",
                         "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -61,7 +62,8 @@
                         "Create pet AI"
                     ],
                     "time_interval_trigger": 900000,
-                    "text": "Work on %g",
+                    "title": "Work on %g",
+                    "body": "Keep focused!",
                     "audio_paths": {
                         "Bloop": "/System/Library/Sounds/Bloop.aiff"
                     }

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -19,9 +19,8 @@
                     "bundle_id": "unity.nomada studio.GRIS",
                     "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"
                 },
-                "Into the Breach": {
+                "Notepad": {
                     "enabled": true,
-                    "bundle_id": "subset.Into-the-Breach",
                     "app_icon_path": "~/Library/Application Support/Lento/Into the Breach.jpg"
                 }
             },
@@ -31,9 +30,8 @@
                     "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
                     "app_icon_path": "~/Library/Application Support/Lento/NetNewsWire.jpg"
                 },
-                "calibre": {
+                "Raindrop.io": {
                     "enabled": false,
-                    "bundle_id": "net.kovidgoyal.calibre",
                     "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
                 }
             },

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -39,6 +39,8 @@
             },
             "notifications": {
                 "a019868e-f43f-478f-8dcc-ba78c35525c4": {
+                    "name": "Test Notif 1",
+                    "enabled": true,
                     "type": "banner",
                     "blocked_visit_triggers": [
                         "youtube.com",
@@ -56,6 +58,8 @@
                     }
                 },
                 "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+                    "name": "Test Notif 2",
+                    "enabled": false,
                     "type": "popup",
                     "blocked_visit_triggers": [ ],
                     "associated_goals": [

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -19,9 +19,10 @@
                     "bundle_id": "unity.nomada studio.GRIS",
                     "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"
                 },
-                "Notepad": {
+                "vivaldi": {
                     "enabled": true,
-                    "app_icon_path": "~/Library/Application Support/Lento/Into the Breach.jpg"
+                    "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
+                    "app_icon_path": "C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
                 }
             },
             "soft_blocked_apps": {
@@ -30,9 +31,10 @@
                     "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
                     "app_icon_path": "~/Library/Application Support/Lento/NetNewsWire.jpg"
                 },
-                "Raindrop.io": {
+                "Trello": {
                     "enabled": false,
-                    "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
+                    "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",
+                    "icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"
                 }
             },
             "notifications": {

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -71,10 +71,10 @@
                     }
                 }
             },
-            "goals": [
-                "Debug pet AI",
-                "Solve USACO problem"
-            ]
+            "goals": {
+                "Debug pet AI": true,
+                "Solve USACO problem": false
+            }
         }
     },
     "application_settings": {

--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -8,7 +8,7 @@
             "time": 5400,
             "hard_blocked_sites": {
                 "twitter.com":  false,
-                "talk.macpowerusers.com": true,
+                "talk.macpowerusers.com": true
             },
             "soft_blocked_sites": {
                 "youtube.com": true
@@ -28,12 +28,12 @@
             "soft_blocked_apps": {
                 "NetNewsWire": {
                     "enabled": true,
-                    "bundle_id": "com.ranchero.NetNewsWire-Evergreen"
+                    "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
                     "app_icon_path": "~/Library/Application Support/Lento/NetNewsWire.jpg"
                 },
                 "calibre": {
                     "enabled": false,
-                    "bundle_id": "net.kovidgoyal.calibre"
+                    "bundle_id": "net.kovidgoyal.calibre",
                     "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
                 }
             },

--- a/docs/lento-log.md
+++ b/docs/lento-log.md
@@ -109,9 +109,17 @@ It's worth talking about some initial obstacles I had to troubleshoot with this 
 I also had to overcome an issue with the scrolling log entry interface. The log interface had to be able to scroll in reverse chronological order, as well as wrap text. I couldn't figure out how to to do this for a while. Eventually, after consulting some online documentation and experimenting with different methods, I managed to settle on a solution using a specific combination of QScrollView() and layouts.
 
 ## 2022-01-16
-Over the last few days, I've been fixing up some smaller issues with Peregrine. I'm coming to a close with my work on it as a prototype for Lento. Soon, I'll port some parts of Peregrine over to Lento and then stop work on Peregrine until after Lento v1.
+`Nathan:` Over the last few days, I've been fixing up some smaller issues with Peregrine. I'm coming to a close with my work on it as a prototype for Lento. Soon, I'll port some parts of Peregrine over to Lento and then stop work on Peregrine until after Lento v1.
 
 The last interesting problem I've encountered with Peregrine involves packaging the Python code into OS-specific app packages. We're using PyInstaller to do this with both Peregrine and Lento. The problem is that PyInstaller requires a certain setup for each OS. For example, the command you need to run to use PyInstaller on macOS differs slightly with the command you need to use on Windows. I spent an hour or two working out the nuances of these setups with Charlie, switching between macOS and Windows to rapidly iterate on my ideas. After a bit of experimenting, I managed to work out the correct configuration for each platform. This was a great experience as I can directly port the PyInstaller setup from Peregrine to Lento, completely avoiding these problems next time.
 
 ## 2022-01-18
-Updated some of the docs for Lento to note down all of the things I've learned from the Peregrine prototype.
+`Nathan:` Updated some of the docs for Lento to note down all of the things I've learned from the Peregrine prototype.
+
+## 2022-01-23
+`Nathan:` Started on the CardsManagement part of the backend. Hoping to write clean code with 100% test coverage. CardsManagement is easier to test and think about than the other parts of the backend so I'm starting with it as a sort of warm-up.
+
+`Charlie:` Started on GUI — Currently learning GUI design with PySide and Qt, wiped computer and set up coding environments again. Currently planning each part of GUI code, scoping out functions needed + requirements + linking w/backend. Experimenting with colours, widget design, page layout, and animations in PySide — mapping out more interfaces as I go.
+
+## 2022-01-25
+We ran through a bunch of [CodeWars](https://www.codewars.com) problems today. While not directly related to Lento, they sharpened our skills with Python, which will make development faster/easier. This is especially important for me (Nathan), as I'm coming from JS/TS and am still getting used to/learning Python.

--- a/docs/lento-log.md
+++ b/docs/lento-log.md
@@ -146,3 +146,11 @@ I'm currently still working on how to do this on Windows. While I'm thinking abo
 I first followed an article giving instructions for how to extract icons from a file using Powershell. This worked on regular .exes. However, I didn't have a filepath to run these commands on for Windows Store apps. After some digging around, I discovered that Windows Store Apps are stored in a folder called `C:\Users\[current_username]\WindowsApps`. Using an administrator-level Powershell window, I navigated through this folder and managed to open up the data folders for some of these apps in File Explorer. Immediately, I noticed that there was a file called `AppxManifest.xml`. Usually manifest files provide metadata, so I opened up one of them in VSCode. A bit of browsing revealed that the path to the app icon files was defined in the `AppxManifest`! I ran a search to see if there was a way to programmatically pull attributes from the `AppxManifest` using Powershell. Sure enough, there was some solid documentation for a command called `Get-AppxManifest`. I tweaked the examples a bit and managed to get it working!
 
 I've documented the exact steps and commands needed to do this on my todo list to implement tomorrow. Hopefully the build will go smoothly now that I have a clear idea of how to extract the app icons.
+
+## 2022-02-13
+`Nathan:` Over the last few days, I've been finishing up CardsManagement. There have been a lot less possibly-fatal errors since the 8th, although I've still come across some minor issues that required some research and troubleshooting:
+- formatting of powershell commands that we want to run from Python (they get passed through cmd.exe first, leading to some necessary formatting changes)
+- making tests involving paths work on both Windows and macOS (different structures/folder conventions need to be accounted for)
+- some weird errors that made it past automated tests (comparing orders of items in dicts)
+
+Other than those, I haven't faced any notable issues and have just about finished CardsManagement. Creating a PR today for code review.

--- a/docs/lento-log.md
+++ b/docs/lento-log.md
@@ -139,3 +139,10 @@ I've also faced some problems with the app blocklists, as they require different
 - **enabled/disabled**: default to enabled, this matches with the user expectations.
 
 I'm currently still working on how to do this on Windows. While I'm thinking about that, I'm also working on some of the last parts of `CardsManagement`, namely notification and goal management.
+
+## 2022-02-08
+`Nathan:` Figured out how to extract app icons on Windows! To understand why this is so hard, it's useful to know that there are 2 types of Windows apps: regular .exes, and Windows Store apps. I didn't understand the distinction between these at first, which led to some problems later on.
+
+I first followed an article giving instructions for how to extract icons from a file using Powershell. This worked on regular .exes. However, I didn't have a filepath to run these commands on for Windows Store apps. After some digging around, I discovered that Windows Store Apps are stored in a folder called `C:\Users\[current_username]\WindowsApps`. Using an administrator-level Powershell window, I navigated through this folder and managed to open up the data folders for some of these apps in File Explorer. Immediately, I noticed that there was a file called `AppxManifest.xml`. Usually manifest files provide metadata, so I opened up one of them in VSCode. A bit of browsing revealed that the path to the app icon files was defined in the `AppxManifest`! I ran a search to see if there was a way to programmatically pull attributes from the `AppxManifest` using Powershell. Sure enough, there was some solid documentation for a command called `Get-AppxManifest`. I tweaked the examples a bit and managed to get it working!
+
+I've documented the exact steps and commands needed to do this on my todo list to implement tomorrow. Hopefully the build will go smoothly now that I have a clear idea of how to extract the app icons.

--- a/docs/lento-log.md
+++ b/docs/lento-log.md
@@ -122,4 +122,20 @@ The last interesting problem I've encountered with Peregrine involves packaging 
 `Charlie:` Started on GUI — Currently learning GUI design with PySide and Qt, wiped computer and set up coding environments again. Currently planning each part of GUI code, scoping out functions needed + requirements + linking w/backend. Experimenting with colours, widget design, page layout, and animations in PySide — mapping out more interfaces as I go.
 
 ## 2022-01-25
-We ran through a bunch of [CodeWars](https://www.codewars.com) problems today. While not directly related to Lento, they sharpened our skills with Python, which will make development faster/easier. This is especially important for me (Nathan), as I'm coming from JS/TS and am still getting used to/learning Python.
+We ran through a bunch of [CodeWars](https://www.codewars.com) problems today. While not directly related to Lento, they sharpened our skills with Python, which will make development faster/easier. This is especially important for Nathan, as he's coming from JS/TS and still getting used to/learning Python.
+
+## 2022-01-28
+`Nathan:` I've been putting some serious work into `CardsManagement` over the last few days. One of the issues I've encountered so far is URL validation. Initially, I wanted to add a check to make sure that when a user adds a URL to a blocklist, a website actually exists at that URL. I also wanted to check to make sure the URL had valid formatting.
+
+However, this turned out to be a lot harder than I originally anticipated. After some research (reading over the original W3C URL spec along with some articles), it turns out that there are so many formats for valid URLs that it's basically impossible to define what a "correct" or "incorrect" URL looks like based on the text alone. Experimenting with different methods also showed that pinging the server at the URL to check for a website also presented issues; we had to consider cases where the user would be offline, where the website would be down, other firewall/router restrictions, etc. Ultimately, we decided to forgo URL validation. While that isn't as clean of a solution as I'd hoped for, it doesn't have any large impact on Lento's UX.
+
+I've also faced some problems with the app blocklists, as they require different methods on macOS and Windows. Right now, I'm not sure how to extract and store all the information we'll need for the blocklists (app name, icon, bundle ID if on macOS, enabled/disabled) on either platform. I'll be investigating this more as I try to finish up the `CardsManagement` section in the next week.
+
+## 2022-02-01
+`Nathan:` I've successfully solved the app blocklists issues on macOS! After some thinking and drawing a few diagrams, I've managed to find methods for extracting each bit of required info:
+- **app name**: parse from the file path by finding what's directly in front of the ".app" string
+- **app icon**: the file name for this is defined in an Info.plist file found inside every app package. After browsing the internet for a while, I've discovered that you can parse these .plist files as Python dictionaries *directly from the Python standard library*! Using the built-in `plistlib` library, I was able to find the file name f the app icon, and then convert it to a .jpg using the `pillow` library. We've decided on storing these in an application support folder, which on macOS is `~/Library/Application Support/Lento/`.
+- **bundle ID**: some research (searching StackOverflow) revealed that there was a command to get the bundle ID from a `.app` file, so I'm running this and then capturing the output.
+- **enabled/disabled**: default to enabled, this matches with the user expectations.
+
+I'm currently still working on how to do this on Windows. While I'm thinking about that, I'm also working on some of the last parts of `CardsManagement`, namely notification and goal management.

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -38,14 +38,14 @@ def read_cards():
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
-    return settings['cards']
+    return settings["cards"]
 
 
 def delete_card(card_to_delete):
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
-    del settings['cards'][card_to_delete]
+    del settings["cards"][card_to_delete]
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -242,3 +242,32 @@ def add_notification(
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)
+
+
+def update_notification_list(card_to_modify, new_notifs_dict):
+    """Update notifications for a card. Minimal validation."""
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if not isinstance(new_notifs_dict, dict):
+        raise Exception("new_notifs_dict is not a dict!")
+    for item in list(new_notifs_dict.keys()):
+        is_notif_dict_valid = set(new_notifs_dict[item].keys()) == set([
+            "name",
+            "enabled",
+            "type",
+            "blocked_visit_triggers",
+            "associated_goals",
+            "time_interval_trigger",
+            "title",
+            "body",
+            "audio_paths"
+        ])
+        if not is_notif_dict_valid:
+            raise Exception(f"Notif {item} had invalid structure!")
+
+    settings["cards"][card_to_modify]["notifications"] = new_notifs_dict
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+from lento.utils import is_url
 
 
 def create_card():
@@ -64,5 +65,26 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
         }
         settings["cards"] = new_cards
 
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def update_site_blocklists(card_to_modify, list_to_modify, new_value):
+    """Update either the `hard_blocked_sites` or `soft_blocked_sites` lists."""
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if settings["cards"][card_to_modify][list_to_modify] is None:
+        raise Exception("List is nonexistent!")
+    elif list_to_modify not in [
+                "hard_blocked_sites",
+                "soft_blocked_sites"
+            ]:
+        raise Exception("Card field is restricted!")
+    elif is_url(new_value) is False:
+        raise Exception("URL not valid!")
+
+    settings["cards"][card_to_modify][list_to_modify][new_value] = True
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -80,7 +80,8 @@ def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
 
-    if settings["cards"][card_to_modify][list_to_modify] is None:
+    card_to_mod = settings["cards"][card_to_modify]
+    if card_to_mod[list_to_modify] is None:
         raise Exception("List is nonexistent!")
     elif list_to_modify not in [
                 "hard_blocked_sites",
@@ -89,6 +90,12 @@ def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
         raise Exception("Card field is restricted!")
     elif is_url(new_value) is False:
         raise Exception("URL not valid!")
+    elif list_to_modify == "hard_blocked_sites":
+        if new_value in card_to_mod["soft_blocked_sites"]:
+            raise Exception(f"'{new_value}' already soft blocked!")
+    elif list_to_modify == "soft_blocked_sites":
+        if new_value in card_to_mod["hard_blocked_sites"]:
+            raise Exception(f"'{new_value}' already hard blocked!")
 
     settings["cards"][card_to_modify][list_to_modify][new_value] = True
     with open(path, "w", encoding="UTF-8") as settings_json:
@@ -127,6 +134,13 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
     if current_os == "Darwin":
         for app in apps_to_add:
             app_name = os.path.basename(app).replace(".app", "")
+
+            if list_to_modify == "hard_blocked_apps":
+                if app_name in card["soft_blocked_apps"]:
+                    raise Exception(f"'{app_name}' already soft blocked!")
+            elif list_to_modify == "soft_blocked_apps":
+                if app_name in card["hard_blocked_apps"]:
+                    raise Exception(f"'{app_name}' already hard blocked!")
 
             bundle_id = subprocess.check_output([
                 "mdls",
@@ -175,6 +189,13 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
             }
     elif current_os == "Windows":
         for app in apps_to_add:
+            app_name = app["name"]
+            if list_to_modify == "hard_blocked_apps":
+                if app_name in card["soft_blocked_apps"]:
+                    raise Exception(f"'{app_name}' already soft blocked!")
+            elif list_to_modify == "soft_blocked_apps":
+                if app_name in card["hard_blocked_apps"]:
+                    raise Exception(f"'{app_name}' already hard blocked!")
             card[list_to_modify][app["name"]] = {
                 "enabled": True,
                 "path": app["path"],

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -153,7 +153,12 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 "app_icon_path": path_to_save_at
             }
     elif current_os == "Windows":
-        print("todo")
+        for app in apps_to_add:
+            card[list_to_modify][app["name"]] = {
+                "enabled": True,
+                "path": app["path"],
+                "app_icon_path": app["icon_path"]
+            }
     else:
         raise Exception("OS name invalid or not found!")
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -75,7 +75,7 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
 
 
 def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
-    """Update either the `hard_blocked_sites` or `soft_blocked_sites` lists."""
+    """Add to either the `hard_blocked_sites` or `soft_blocked_sites` lists."""
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
@@ -91,6 +91,27 @@ def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
         raise Exception("URL not valid!")
 
     settings["cards"][card_to_modify][list_to_modify][new_value] = True
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def update_site_blocklists(card_to_modify, list_to_modify, new_sites_dict):
+    """Update one of the blocked_sites lists. Minimal validation."""
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if settings["cards"][card_to_modify][list_to_modify] is None:
+        raise Exception("List is nonexistent!")
+    elif list_to_modify not in [
+                "hard_blocked_sites",
+                "soft_blocked_sites"
+            ]:
+        raise Exception("Card field is restricted!")
+    elif not isinstance(new_sites_dict, dict):
+        raise Exception("new_sites_dict is not a dict!")
+
+    settings["cards"][card_to_modify][list_to_modify] = new_sites_dict
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -51,6 +51,11 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
 
     if settings["cards"][card_to_modify][field_to_modify] is None:
         raise Exception("Card field is nonexistent!")
+    elif field_to_modify not in ["name", "emoji", "time"]:
+        raise Exception("Card field is restricted!")
+    elif field_to_modify == "time":
+        new_value = float(new_value)
+
     settings["cards"][card_to_modify][field_to_modify] = new_value
     if field_to_modify == "name":
         new_cards = {

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -162,7 +162,8 @@ def add_notification(
             blocked_visit_triggers,
             associated_goals,
             time_interval_trigger,
-            text,
+            title,
+            body,
             audio_paths
         ):
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
@@ -189,15 +190,18 @@ def add_notification(
             raise Exception("Associated goals not found in goal list!")
     if not isinstance(time_interval_trigger, int) and time_interval_trigger is not None:  # noqa: E501
         raise Exception("Timer interval trigger is not an integer or None!")
-    elif not isinstance(text, str) and text is not None:
-        raise Exception("Notification text is not a string!")
+    elif not isinstance(title, str) and title is not None:
+        raise Exception("Notification title is not a string!")
+    elif not isinstance(body, str) and body is not None:
+        raise Exception("Notification body is not a string!")
 
     new_notif = {
         "type": type,
         "blocked_visit_triggers": blocked_visit_triggers,
         "associated_goals": associated_goals,
         "time_interval_trigger": time_interval_trigger,
-        "text": text,
+        "title": title,
+        "body": body,
         "audio_paths": audio_paths
     }
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -8,7 +8,7 @@ def create_card():
         "id": str(uuid.uuid4().hex),
         "name": "Untitled Card",
         "emoji": "😃",
-        "time": "0",
+        "time": 0,
         "hard_blocked_sites": {},
         "soft_blocked_sites": {},
         "hard_blocked_apps": {},
@@ -40,5 +40,24 @@ def delete_card(card_to_delete):
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
     del settings['cards'][card_to_delete]
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def update_metadata(card_to_modify, field_to_modify, new_value):
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if settings["cards"][card_to_modify][field_to_modify] is None:
+        raise Exception("Card field is nonexistent!")
+    settings["cards"][card_to_modify][field_to_modify] = new_value
+    if field_to_modify == "name":
+        new_cards = {
+            new_value if k == card_to_modify
+            else k: v for k, v in settings["cards"].items()
+        }
+        settings["cards"] = new_cards
+
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -5,6 +5,7 @@ import plistlib
 import subprocess
 import uuid
 from lento import utils
+from lento.config import Config
 from lento.utils import is_url
 from PIL import Image
 
@@ -115,6 +116,11 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 app
             ]).decode("utf-8")
 
+            if app[:14] == "/Applications/":
+                app = os.path.join(
+                    Config.MACOS_APPLICATION_FOLDER,
+                    app_name + ".app",
+                )
             with open(app + "/Contents/Info.plist", "rb") as fp:
                 app_plist = plistlib.load(fp)
             icon_name = app_plist["CFBundleIconFile"]

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -119,14 +119,26 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
             if app[:14] == "/Applications/":
                 app = os.path.join(
                     Config.MACOS_APPLICATION_FOLDER,
-                    app_name + ".app",
+                    app_name + ".app"
                 )
-            with open(app + "/Contents/Info.plist", "rb") as fp:
+                plist_path = os.path.join(
+                    app,
+                    "Contents",
+                    "Info.plist"
+                )
+            else:
+                plist_path = os.path.join(app, "Contents", "Info.plist")
+            with open(plist_path, "rb") as fp:
                 app_plist = plistlib.load(fp)
             icon_name = app_plist["CFBundleIconFile"]
             if icon_name[-5:] != ".icns":
                 icon_name = app_plist["CFBundleIconFile"] + ".icns"
-            original_icon_path = app + "/Contents/Resources/" + icon_name
+            original_icon_path = os.path.join(
+                app,
+                "Contents",
+                "Resources",
+                icon_name
+            )
             im = Image.open(original_icon_path)
             rgb_im = im.convert("RGB")
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -198,7 +198,7 @@ def update_app_blocklists(card_to_modify, list_to_modify, new_list_structure):
             ]:
         raise Exception("Card field is restricted!")
 
-    settings["cards"][card_to_modify][list_to_modify] == new_list_structure
+    settings["cards"][card_to_modify][list_to_modify] = new_list_structure
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -21,7 +21,7 @@ def create_card():
         "hard_blocked_apps": {},
         "soft_blocked_apps": {},
         "notifications": {},
-        "goals": []
+        "goals": {}
     }
 
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
@@ -268,6 +268,21 @@ def update_notification_list(card_to_modify, new_notifs_dict):
             raise Exception(f"Notif {item} had invalid structure!")
 
     settings["cards"][card_to_modify]["notifications"] = new_notifs_dict
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def add_goal(card_to_modify: str, goal_to_add: str) -> None:
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if not isinstance(goal_to_add, str):
+        raise Exception("Goal to add is not string!")
+
+    settings["cards"][card_to_modify]["goals"][goal_to_add] = False
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -137,3 +137,20 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)
+
+
+def update_app_blocklists(card_to_modify, list_to_modify, new_list_structure):
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if list_to_modify not in [
+                "hard_blocked_apps",
+                "soft_blocked_apps"
+            ]:
+        raise Exception("Card field is restricted!")
+
+    settings["cards"][card_to_modify][list_to_modify] == new_list_structure
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -74,7 +74,7 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
         json.dump(settings, settings_json)
 
 
-def update_site_blocklists(card_to_modify, list_to_modify, new_value):
+def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
     """Update either the `hard_blocked_sites` or `soft_blocked_sites` lists."""
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
     with open(path, "r", encoding="UTF-8") as settings_json:

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -157,6 +157,8 @@ def update_app_blocklists(card_to_modify, list_to_modify, new_list_structure):
 
 
 def add_notification(
+            name,
+            enabled,
             card_to_modify,
             type,
             blocked_visit_triggers,
@@ -170,7 +172,11 @@ def add_notification(
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
 
-    if type not in ["banner", "popup", "audio"]:
+    if not isinstance(name, str):
+        raise Exception("Name must be a string!")
+    elif not isinstance(enabled, bool):
+        raise Exception("Enabled must be a boolean!")
+    elif type not in ["banner", "popup", "audio"]:
         raise Exception("Notification type not valid!")
     elif not isinstance(blocked_visit_triggers, list):
         raise Exception("Blocked visit triggers is not a list!")
@@ -196,6 +202,8 @@ def add_notification(
         raise Exception("Notification body is not a string!")
 
     new_notif = {
+        "name": name,
+        "enabled": enabled,
         "type": type,
         "blocked_visit_triggers": blocked_visit_triggers,
         "associated_goals": associated_goals,

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -4,7 +4,6 @@ import platform
 import plistlib
 import subprocess
 import uuid
-from lento import utils
 from lento.config import Config
 from lento.utils import is_url
 from PIL import Image
@@ -154,8 +153,7 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 "app_icon_path": path_to_save_at
             }
     elif current_os == "Windows":
-        e = utils.get_apps()
-        print(json.dumps(e, indent=4))
+        print("todo")
     else:
         raise Exception("OS name invalid or not found!")
 

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -274,6 +274,7 @@ def update_notification_list(card_to_modify, new_notifs_dict):
 
 
 def add_goal(card_to_modify: str, goal_to_add: str) -> None:
+    """Add a goal to a card. Automatically adds as disabled."""
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
 
     with open(path, "r", encoding="UTF-8") as settings_json:
@@ -283,6 +284,24 @@ def add_goal(card_to_modify: str, goal_to_add: str) -> None:
         raise Exception("Goal to add is not string!")
 
     settings["cards"][card_to_modify]["goals"][goal_to_add] = False
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def update_goal_list(card_to_modify, new_goals_dict):
+    """Update goals for a card. Minimal validation."""
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    if not isinstance(new_goals_dict, dict):
+        raise Exception("new_goals_dict is not a dict!")
+    for item in list(new_goals_dict.keys()):
+        if not isinstance(new_goals_dict[item], bool):
+            raise Exception(f"Goal '{item}' has invalid structure!")
+
+    settings["cards"][card_to_modify]["goals"] = new_goals_dict
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -33,3 +33,12 @@ def read_cards():
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
     return settings['cards']
+
+
+def delete_card(card_to_delete):
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+    del settings['cards'][card_to_delete]
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -103,10 +103,10 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
 
     card = settings["cards"][card_to_modify]
 
-    for app in apps_to_add:
-        current_os = platform.system()
-        if current_os == "Darwin":
-            app_name = app[app.rindex("/")+1:].replace(".app", "")
+    current_os = platform.system()
+    if current_os == "Darwin":
+        for app in apps_to_add:
+            app_name = os.path.basename(app).replace(".app", "")
 
             bundle_id = subprocess.check_output([
                 "mdls",
@@ -153,11 +153,11 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 "bundle_id": bundle_id,
                 "app_icon_path": path_to_save_at
             }
-        elif current_os == "Windows":
-            e = utils.get_apps()
-            print(e)
-        else:
-            raise Exception("OS name invalid or not found!")
+    elif current_os == "Windows":
+        e = utils.get_apps()
+        print(json.dumps(e, indent=4))
+    else:
+        raise Exception("OS name invalid or not found!")
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -4,6 +4,7 @@ import platform
 import plistlib
 import subprocess
 import uuid
+from lento import utils
 from lento.utils import is_url
 from PIL import Image
 
@@ -134,6 +135,11 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 "bundle_id": bundle_id,
                 "app_icon_path": path_to_save_at
             }
+        elif current_os == "Windows":
+            e = utils.get_apps()
+            print(e)
+        else:
+            raise Exception("OS name invalid or not found!")
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -26,3 +26,10 @@ def create_card():
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)
+
+
+def read_cards():
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+    return settings['cards']

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -1,5 +1,7 @@
 import json
 import os
+import platform
+import subprocess
 import uuid
 from lento.utils import is_url
 
@@ -86,5 +88,28 @@ def update_site_blocklists(card_to_modify, list_to_modify, new_value):
         raise Exception("URL not valid!")
 
     settings["cards"][card_to_modify][list_to_modify][new_value] = True
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)
+
+
+def update_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    card = settings["cards"][card_to_modify]
+
+    for app in apps_to_add:
+        current_os = platform.system()
+        if current_os == "Darwin":
+            bundle_id = subprocess.check_output([
+                "mdls",
+                "-name",
+                "kMDItemCFBundleIdentifier",
+                "-r",
+                app
+            ])
+            card[list_to_modify][bundle_id.decode("utf-8")] = True
+
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(settings, settings_json)

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -1,0 +1,28 @@
+import json
+import os
+import uuid
+
+
+def create_card():
+    new_card = {
+        "id": str(uuid.uuid4().hex),
+        "name": "Untitled Card",
+        "emoji": "😃",
+        "time": "0",
+        "hard_blocked_sites": {},
+        "soft_blocked_sites": {},
+        "hard_blocked_apps": {},
+        "soft_blocked_apps": {},
+        "notifications": {},
+        "goals": []
+    }
+
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    settings["cards"][new_card["name"]] = new_card
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(settings, settings_json)

--- a/lento/config.py
+++ b/lento/config.py
@@ -1,6 +1,7 @@
 """App instance configuration."""
 import os
 import dotenv
+from pathlib import Path
 from lento import utils
 
 dotenv.load_dotenv(dotenv_path=utils.get_data_file_path('.env'), override=True)
@@ -8,3 +9,4 @@ dotenv.load_dotenv(dotenv_path=utils.get_data_file_path('.env'), override=True)
 
 class Config:
     TEST_VAR = os.getenv('TEST_VAR')
+    MACOS_APPLICATION_FOLDER = Path("/Applications/")

--- a/lento/config.py
+++ b/lento/config.py
@@ -1,12 +1,23 @@
 """App instance configuration."""
-import os
 import dotenv
+import os
+import sys
 from pathlib import Path
-from lento import utils
 
-dotenv.load_dotenv(dotenv_path=utils.get_data_file_path('.env'), override=True)
+
+def get_data_file_path(relative_path):
+    try:
+        base = sys._MEIPASS
+    except Exception:
+        base = os.path.abspath('.')
+
+    return os.path.join(base, relative_path)
+
+
+dotenv.load_dotenv(dotenv_path=get_data_file_path('.env'), override=True)  # noqa: E501
 
 
 class Config:
     TEST_VAR = os.getenv('TEST_VAR')
     MACOS_APPLICATION_FOLDER = Path("/Applications/")
+    DRIVE_LETTER = "C:\\"

--- a/lento/gui/mainwindow.py
+++ b/lento/gui/mainwindow.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import QSize
-from PySide6.QtWidgets import QApplication, QLabel, QMainWindow, QVBoxLayout, QWidget  # noqa: E501
+from PySide6.QtWidgets import QApplication, QFileDialog, QLabel, QMainWindow, QPushButton, QVBoxLayout, QWidget  # noqa: E501
 
 
 class MainWindow(QMainWindow):
@@ -15,12 +15,25 @@ class MainWindow(QMainWindow):
 
         layout = QVBoxLayout()
         text = QLabel("Hello World!")
+        button = QPushButton("Summon Llama")
+        button.setEnabled(True)
+        button.clicked.connect(self.add_item)
 
         layout.addWidget(text)
+        layout.addWidget(button)
         widget = QWidget()
         widget.setLayout(layout)
 
         self.setCentralWidget(widget)
+
+    def add_item(self):
+        dialog = QFileDialog()
+        dialog.setFileMode(QFileDialog.ExistingFiles)
+        dialog.setDirectory("/Applications/")
+        dialog.setNameFilter(("Applications (*.app)"))
+        if dialog.exec():
+            fileNames = dialog.selectedFiles()
+            print(fileNames)
 
 
 def main():

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -35,9 +35,6 @@ def get_apps():
     apps = []
     if current_os == "Windows":
         print("todo")
-        # Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate
-        # Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate
-        # Get-ChildItem os.path.join(os.path.expanduser("~") + "Program Files/WindowsApps/")
 
     elif current_os == "Darwin":
         raise Exception("This function does not currently support macOS.")

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 import sys
 from urllib.parse import urlparse
+from pathlib import Path
 
 
 def get_data_file_path(relative_path):
@@ -40,21 +41,17 @@ def get_apps():
         items = remove_dupes_blanks_and_whitespace(raw_data[3:])
         for app_path in items:
             app_name = os.path.basename(app_path).replace(".exe", "")
-            if "C:\\Program Files\\WindowsApps" in app_path:
+            if os.path.join("C:", "Program Files", "WindowsApps") in app_path:
                 command = f"powershell \"(Get-AppxPackage -Name \"*{app_name}*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\""  # noqa: E501
                 app_icon = subprocess.getoutput(command)
                 if app_icon == "":
                     app_icon_path = None
                 else:
-                    package_name = app_path.replace(
-                        "C:\\Program Files\\WindowsApps\\",
-                        ""
-                    )
                     app_icon_path = os.path.join(
-                        "C:\\",
+                        "C:",
                         "Program Files",
                         "WindowsApps",
-                        package_name[:package_name.index("\\")+1],
+                        Path(app_path).parts[3],
                         "".join([
                             app_icon[:-4],
                             ".scale-200.png"

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -35,8 +35,12 @@ def get_apps():
     apps = []
     if current_os == "Windows":
         print("todo")
+        # Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate
+        # Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate
+        # Get-ChildItem os.path.join(os.path.expanduser("~") + "Program Files/WindowsApps/")
+
     elif current_os == "Darwin":
-        print("todo_darwing")
+        raise Exception("This function does not currently support macOS.")
     else:
         raise Exception(
             "Something went wrong and the OS name could not be found."

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -34,10 +34,10 @@ def is_url(url):
 
 def get_apps():
     current_os = platform.system()
-    apps = []
+    apps = {}
     if current_os == "Windows":
-        raw_data = subprocess.getoutput("Get-StartApps | convertto-json")
-        app_data = json.loads(raw_data)
+        command = "powershell \"Get-StartApps | convertto-json\""
+        app_data = json.loads(subprocess.getoutput(command))
         for app in app_data:
             apps[app['Name']] = app['AppID']
     elif current_os == "Darwin":

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from urllib.parse import urlparse
 
 
 def get_data_file_path(relative_path):
@@ -9,3 +10,20 @@ def get_data_file_path(relative_path):
         base = os.path.abspath('.')
 
     return os.path.join(base, relative_path)
+
+
+def is_url(url):
+    scheme_included = False
+    schemes_to_check = ["https://", "http://", "file://", "ftp://"]
+    for scheme in schemes_to_check:
+        if len(scheme) <= len(url) and url[:len(scheme)] == scheme:
+            scheme_included = True
+
+    if not scheme_included:
+        url = "https://" + url
+
+    result = urlparse(url)
+    if "." not in result.netloc:
+        return False
+
+    return True

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 from urllib.parse import urlparse
 
@@ -27,3 +28,18 @@ def is_url(url):
         return False
 
     return True
+
+
+def get_apps():
+    current_os = platform.system()
+    apps = []
+    if current_os == "Windows":
+        print("todo")
+    elif current_os == "Darwin":
+        print("todo_darwing")
+    else:
+        raise Exception(
+            "Something went wrong and the OS name could not be found."
+        )
+
+    return(apps)

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -1,5 +1,7 @@
+import json
 import os
 import platform
+import subprocess
 import sys
 from urllib.parse import urlparse
 
@@ -34,8 +36,10 @@ def get_apps():
     current_os = platform.system()
     apps = []
     if current_os == "Windows":
-        print("todo")
-
+        raw_data = subprocess.getoutput("Get-StartApps | convertto-json")
+        app_data = json.loads(raw_data)
+        for app in app_data:
+            apps[app['Name']] = app['AppID']
     elif current_os == "Darwin":
         raise Exception("This function does not currently support macOS.")
     else:

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -42,7 +42,7 @@ def get_apps():
         items = remove_dupes_blanks_and_whitespace(raw_data[3:])
         for app_path in items:
             app_name = os.path.basename(app_path).replace(".exe", "")
-            if os.path.join(Config.DRIVE_LETTER, "Program Files", "WindowsApps") in app_path:
+            if os.path.join(Config.DRIVE_LETTER, "Program Files", "WindowsApps") in app_path:  # noqa: E501
                 command = f"powershell \"(Get-AppxPackage -Name \"*{app_name}*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\""  # noqa: E501
                 app_icon = subprocess.getoutput(command)
                 if app_icon == "":

--- a/lento/utils.py
+++ b/lento/utils.py
@@ -68,7 +68,8 @@ def get_apps():
                     "Lento",
                     f"{app_name}.bmp"
                 )
-                command_string = f"""Add-Type -AssemblyName System.Drawing
+                if not os.path.exists(app_icon_path):
+                    command_string = f"""Add-Type -AssemblyName System.Drawing
                     [System.Drawing.Icon]::ExtractAssociatedIcon(\'{app_path}\').toBitmap().Save(\'{app_icon_path}\')"""  # noqa: E501
                 command = f"powershell \"{command_string}\""
                 subprocess.call(command, shell=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ PySide6>=6.2.2.1
 watchdog>=2.1.6
 pyobjc>=8.1
 python-dotenv>=0.19.2
+# psutil>=5.9.0
+pillow>=9.0.0
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 PySide6>=6.2.2.1
 # watchdog>=2.1.6
 # pyobjc>=8.1
-# python-dotenv>=0.19.2
 # psutil>=5.9.0
+python-dotenv>=0.19.2
 pillow>=9.0.0
 
 # Dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Prod
 PySide6>=6.2.2.1
-watchdog>=2.1.6
-pyobjc>=8.1
-python-dotenv>=0.19.2
+# watchdog>=2.1.6
+# pyobjc>=8.1
+# python-dotenv>=0.19.2
 # psutil>=5.9.0
 pillow>=9.0.0
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ data = {
                 "hard_blocked_apps": {},
                 "soft_blocked_apps": {},
                 "notifications": {},
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {
@@ -39,7 +39,7 @@ data = {
                 "hard_blocked_apps": {},
                 "soft_blocked_apps": {},
                 "notifications": {},
-                "goals": []
+                "goals": {}
             },
             "Llama Taming": {
                 "id": "e68d8993-ee30-4e3f-941b-43c074e2759c",
@@ -75,7 +75,7 @@ data = {
                         }
                     }
                 },
-                "goals": ["Obtain llama"]
+                "goals": {"Obtain llama": True}
             }
         },
         "application_settings": {
@@ -95,7 +95,7 @@ data = {
                 "hard_blocked_apps": {},
                 "soft_blocked_apps": {},
                 "notifications": {},
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {
@@ -126,7 +126,7 @@ data = {
                 },
                 "soft_blocked_apps": {},
                 "notifications": {},
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {
@@ -157,7 +157,7 @@ data = {
                 },
                 "soft_blocked_apps": {},
                 "notifications": {},
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {
@@ -209,7 +209,7 @@ data = {
                         }
                     }
                 },
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {
@@ -264,7 +264,7 @@ data = {
                         }
                     }
                 },
-                "goals": []
+                "goals": {}
             }
         },
         "application_settings": {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -799,6 +799,33 @@ data = {
                 "Bloop": "/System/Library/Sounds/Bloop.aiff"
             }
         }
+    },
+    "bare_config_with_goals": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": {
+                    "Debug USACO problem": True,
+                    "Conquer world": False
+                }
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "reordered_goal_dict": {
+        "Conquer world": False,
+        "Debug USACO problem": True
     }
 }
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+import os
+
 data = {
     "initial_blank_config": {
         "is_block_running": False,
@@ -830,24 +832,47 @@ data = {
     },
     "proper_apps_dict": {
         "Trello": {
-            "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",
-            "icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"
+            "path": str(os.path.join(
+                "C:",
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "app",
+                "Trello.exe"
+            )),
+            "icon_path": str(os.path.join(
+                "C:",
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "assets",
+                "Square310x310Logo.scale-200.png"
+            ))
         },
-        "vivaldi": {
-            "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
-            "icon_path": "C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
-        }
+        "vivaldi": { }
     },
     "apps_to_add": [
         {
             "name": "Trello",
-            "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",
-            "icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"
+            "path": str(os.path.join(
+                "C:",
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "app",
+                "Trello.exe"
+            )),
+            "icon_path": str(os.path.join(
+                "C:",
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "assets",
+                "Square310x310Logo.scale-200.png"
+            ))
         },
         {
             "name": "vivaldi",
-            "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
-            "icon_path": "C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
         }
     ]
 }
@@ -873,15 +898,37 @@ class fake_rgb:
         return True
 
 def fake_subprocess(cmd):
+    correct_trello_path = "".join([
+        str(os.path.join(
+            "C:",
+            "Program Files",
+            "WindowsApps",
+            "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+            "app",
+            "Trello.exe"
+        )),
+        "   "
+    ])
+    correct_vivaldi_path = "".join([
+        str(os.path.join(
+            os.path.expanduser("~"),
+            "AppData",
+            "Local",
+            "Vivaldi",
+            "Application",
+            "vivaldi.exe"
+        )),
+        "   "
+    ])
     cases = {
-        "powershell \"Get-Process -FileVersionInfo -ErrorAction SilentlyContinue | Select-Object FileName\"": """     
+        "powershell \"Get-Process -FileVersionInfo -ErrorAction SilentlyContinue | Select-Object FileName\"": f"""     
 FileName   
 --------   
-C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe   
-C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe   
-C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   
-C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   """,
-            "powershell \"(Get-AppxPackage -Name \"*Trello*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\"": "assets\\Square310x310Logo.png",
+{correct_trello_path}
+{correct_trello_path}
+{correct_vivaldi_path}
+{correct_vivaldi_path}""",
+            "powershell \"(Get-AppxPackage -Name \"*Trello*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\"": os.path.join("assets", "Square310x310Logo.png"),
             "powershell \"{Add-Type -AssemblyName System.Drawing\n[System.Drawing.Icon]::ExtractAssociatedIcon(\'{app_path}\').toBitmap().Save(\'{app_icon_path}\')command_string}\"": ""
     }
     return cases[cmd]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -835,9 +835,21 @@ data = {
         },
         "vivaldi": {
             "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
-            "icon_path": f"C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
+            "icon_path": "C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
         }
-    }
+    },
+    "apps_to_add": [
+        {
+            "name": "Trello",
+            "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",
+            "icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"
+        },
+        {
+            "name": "vivaldi",
+            "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
+            "icon_path": "C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
+        }
+    ]
 }
 
 
@@ -869,7 +881,7 @@ C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb
 C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe   
 C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   
 C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   """,
-            "powershell \"(Get-AppxPackage -Name \"*Trello*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\"": "assets\Square310x310Logo.png",
+            "powershell \"(Get-AppxPackage -Name \"*Trello*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\"": "assets\\Square310x310Logo.png",
             "powershell \"{Add-Type -AssemblyName System.Drawing\n[System.Drawing.Icon]::ExtractAssociatedIcon(\'{app_path}\').toBitmap().Save(\'{app_icon_path}\')command_string}\"": ""
     }
     return cases[cmd]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -98,6 +98,80 @@ data = {
         "application_settings": {
             "theme": "automatic"
         }
+    },
+    "bare_config_with_apps": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {
+                    "calibre": {
+                        "enabled": False,
+                        "bundle_id": "net.kovidgoyal.calibre",
+                        "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"  # noqa: E501
+                    },
+                    "GRIS": {
+                        "enabled": True,
+                        "bundle_id": "unity.nomada studio.GRIS",
+                        "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"  # noqa: E501
+                    }
+                },
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "bare_config_reordered_apps": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {
+                    "GRIS": {
+                        "enabled": True,
+                        "bundle_id": "unity.nomada studio.GRIS",
+                        "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"  # noqa: E501
+                    },
+                    "calibre": {
+                        "enabled": False,
+                        "bundle_id": "net.kovidgoyal.calibre",
+                        "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"  # noqa: E501
+                    }
+                },
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "new_blocklist": {
+        "GRIS": {
+            "enabled": True,
+            "bundle_id": "unity.nomada studio.GRIS",
+            "app_icon_path": "~/Library/Application Support/Lento/GRIS.jpg"
+        },
+        "calibre": {
+            "enabled": False,
+            "bundle_id": "net.kovidgoyal.calibre",
+            "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
+        }
     }
 }
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -216,6 +216,466 @@ data = {
             "theme": "automatic"
         }
     },
+    "GRIS": """<?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>GRIS</string>
+    <key>CFBundleGetInfoString</key>
+    <string>Unity Player version 2017.4.10f1 (f2cce2a5991f). (c) 2018 Unity Technologies ApS. All rights reserved.</string>
+    <key>CFBundleIconFile</key>
+    <string>PlayerIcon.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>unity.nomada studio.GRIS</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+        <array>
+            <string>MacOSX</string>
+        </array>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>CFBundleName</key>
+    <string>GRIS</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>0</string>
+    <key>NSMainNibFile</key>
+    <string>MainMenu</string>
+    <key>NSPrincipalClass</key>
+    <string>PlayerApplication</string>
+    <key>UnityBuildNumber</key>
+    <string>f2cce2a5991f</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.9.0</string>
+</dict>
+</plist>""",
+    "Scrivener": """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ATSApplicationFontsPath</key>
+    <string>Fonts</string>
+    <key>BuildMachineOSBuild</key>
+    <string>20B29</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>scrivx</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>ScrivenerXML</string>
+            <key>CFBundleTypeName</key>
+            <string>Scrivener XML document</string>
+            <key>CFBundleTypeOSTypes</key>
+            <array>
+                <string>scrivx</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+            <key>LSTypeIsPackage</key>
+            <false/>
+            <key>NSDocumentClass</key>
+            <string>SCRMainDocument</string>
+            <key>NSPersistentStoreTypeKey</key>
+            <string>XML</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>scriv</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>ScrivenerDocument</string>
+            <key>CFBundleTypeName</key>
+            <string>Scrivener Project</string>
+            <key>CFBundleTypeOSTypes</key>
+            <array>
+                <string>scriv</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+            <key>LSTypeIsPackage</key>
+            <string>YES</string>
+            <key>NSDocumentClass</key>
+            <string>SCRMainDocument</string>
+            <key>NSPersistentStoreTypeKey</key>
+            <string>Binary</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>scrivtemplate</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>ScrivenerTemplate</string>
+            <key>CFBundleTypeName</key>
+            <string>Scrivener Template</string>
+            <key>CFBundleTypeRole</key>
+            <string>None</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+            <key>NSDocumentClass</key>
+            <string>SCRMainDocument</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>scrformat</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>CompileFormat</string>
+            <key>CFBundleTypeMIMETypes</key>
+            <array/>
+            <key>CFBundleTypeName</key>
+            <string>Scrivener Compile Format</string>
+            <key>CFBundleTypeRole</key>
+            <string>None</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string>
+            <key>LSTypeIsPackage</key>
+            <integer>0</integer>
+            <key>NSDocumentClass</key>
+            <string>SCRMainDocument</string>
+        </dict>
+    </array>
+    <key>CFBundleExecutable</key>
+    <string>Scrivener</string>
+    <key>CFBundleHelpBookFolder</key>
+    <string>Help</string>
+    <key>CFBundleHelpBookName</key>
+    <string>Scrivener Help</string>
+    <key>CFBundleIconFile</key>
+    <string>Scrivener</string>
+    <key>CFBundleIconName</key>
+    <string>Scrivener</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.literatureandlatte.scrivener3</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Scrivener</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>3.2.2</string>
+    <key>CFBundleSignature</key>
+    <string>Scrv</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>Scrivener Reference</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>x-scrivener-item</string>
+            </array>
+            <key>LSIsAppleDefaultForScheme</key>
+            <true/>
+        </dict>
+    </array>
+    <key>CFBundleVersion</key>
+    <string>14632</string>
+    <key>DTCompiler</key>
+    <string>com.apple.compilers.llvm.clang.1_0</string>
+    <key>DTPlatformBuild</key>
+    <string>12B45b</string>
+    <key>DTPlatformName</key>
+    <string>macosx</string>
+    <key>DTPlatformVersion</key>
+    <string>11.0</string>
+    <key>DTSDKBuild</key>
+    <string>20A2408</string>
+    <key>DTSDKName</key>
+    <string>macosx11.0</string>
+    <key>DTXcode</key>
+    <string>1220</string>
+    <key>DTXcodeBuild</key>
+    <string>12B45b</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.productivity</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.12</string>
+    <key>NSAccentColorName</key>
+    <string>AccentColor</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Scrivener uses Apple Events to communicate with MathType for inserting equations, for receiving text from bibliography managers, and to allow quick access to the system's text preferences.</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Â© Literature &amp; Latte 2005-2020</string>
+    <key>NSMainNibFile</key>
+    <string>MainMenu</string>
+    <key>NSPrincipalClass</key>
+    <string>SCRApplication</string>
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Make New Clipping</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>createClipping</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Make New Clipping (Unformatted)</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>createPlainTextClipping</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Append to Text</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>appendSelection</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Append to Text (Unformatted)</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>appendSelectionAsPlainText</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Append to Notes</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>appendSelectionToNotes</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Scrivener/Scrivener: Append to Notes (Unformatted)</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>appendSelectionToNotesAsPlainText</string>
+            <key>NSPortName</key>
+            <string>Scrivener</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>com.apple.flat-rtfd</string>
+                <string>public.rtf</string>
+                <string>public.utf8-plain-text</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>https://www.literatureandlatte.com/downloads/scrivener-3.xml</string>
+    <key>SUPublicDSAKeyFile</key>
+    <string>dsa_pub.pem</string>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.xml</string>
+            </array>
+            <key>UTTypeDescription</key>
+            <string>Scrivener Compile Format</string>
+            <key>UTTypeIconFile</key>
+            <string>CompileFormat</string>
+            <key>UTTypeIdentifier</key>
+            <string>com.literatureandlatte.scrformat</string>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>scrformat</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>""",  # noqa: E501
+    "NetNewsWire": """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AppGroup</key>
+    <string>group.com.ranchero.NetNewsWire-Evergreen</string>
+    <key>AppIdentifierPrefix</key>
+    <string>M8L2WTLA8W.</string>
+    <key>BuildMachineOSBuild</key>
+    <string>20D91</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>NetNewsWire</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIconName</key>
+    <string>AppIcon</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.ranchero.NetNewsWire-Evergreen</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>NetNewsWire</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>6.0.2</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>RSS Feed</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>feed</string>
+                <string>feeds</string>
+            </array>
+        </dict>
+    </array>
+    <key>CFBundleVersion</key>
+    <string>6032</string>
+    <key>DTCompiler</key>
+    <string>com.apple.compilers.llvm.clang.1_0</string>
+    <key>DTPlatformBuild</key>
+    <string>12D4e</string>
+    <key>DTPlatformName</key>
+    <string>macosx</string>
+    <key>DTPlatformVersion</key>
+    <string>11.1</string>
+    <key>DTSDKBuild</key>
+    <string>20C63</string>
+    <key>DTSDKName</key>
+    <string>macosx11.1</string>
+    <key>DTXcode</key>
+    <string>1240</string>
+    <key>DTXcodeBuild</key>
+    <string>12D4e</string>
+    <key>DeveloperEntitlements</key>
+    <string></string>
+    <key>FeedURLForTestBuilds</key>
+    <string>https://ranchero.com/downloads/netnewswire-beta.xml</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.news</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+    <key>NSAccentColorName</key>
+    <string>AccentColor</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>NetNewsWire communicates with other apps on your Mac when you choose to share an article.</string>
+    <key>NSAppleScriptEnabled</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright Â© 2002-2021 Brent Simmons. All rights reserved.</string>
+    <key>NSMainStoryboardFile</key>
+    <string>Main</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSUserActivityTypes</key>
+    <array>
+        <string>ReadArticle</string>
+    </array>
+    <key>OSAScriptingDefinition</key>
+    <string>NetNewsWire.sdef</string>
+    <key>OrganizationIdentifier</key>
+    <string>com.ranchero</string>
+    <key>SUFeedURL</key>
+    <string>https://ranchero.com/downloads/netnewswire-release.xml</string>
+    <key>UserAgent</key>
+    <string>NetNewsWire (RSS Reader; https://netnewswire.com/)</string>
+</dict>
+</plist>"""  # noqa: E501
 }
 
 
@@ -227,3 +687,13 @@ def fake_bundle_id(args):
         "/Applications/NetNewsWire.app": b"com.ranchero.NetNewsWire-Evergreen"
     }
     return cases[app]
+
+
+class fake_image:
+    def convert(x):
+        return fake_rgb
+
+
+class fake_rgb:
+    def save(x):
+        return True

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -172,7 +172,44 @@ data = {
             "bundle_id": "net.kovidgoyal.calibre",
             "app_icon_path": "~/Library/Application Support/Lento/calibre.jpg"
         }
-    }
+    },
+    "bare_config_with_notif": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {
+                    "a019868e-f43f-478f-8dcc-ba78c35525c4": {
+                        "type": "banner",
+                        "blocked_visit_triggers": [
+                            "youtube.com",
+                            "twitter.com"
+                        ],
+                        "associated_goals": [
+                            "Debug USACO problem"
+                        ],
+                        "time_interval_trigger": None,
+                        "text": "Get back to %g!",
+                        "audio_paths": {
+                            "reminder": "~/Desktop/reminder.mp3",
+                            "Frog": "/System/Library/Sounds/Frog.aiff"
+                        }
+                    }
+                },
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
 }
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -66,7 +66,8 @@ data = {
                             "Obtain llama"
                         ],
                         "time_interval_trigger": 900000,
-                        "text": "Work on %g",
+                        "title": "Get back to %g!",
+                        "body": "Keep focused!",
                         "audio_paths": {
                             "Bloop": "/System/Library/Sounds/Bloop.aiff"
                         }
@@ -196,7 +197,8 @@ data = {
                             "Debug USACO problem"
                         ],
                         "time_interval_trigger": None,
-                        "text": "Get back to %g!",
+                        "title": "Get back to %g!",
+                        "body": "Keep focused!",
                         "audio_paths": {
                             "reminder": "~/Desktop/reminder.mp3",
                             "Frog": "/System/Library/Sounds/Frog.aiff"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 data = {
     "initial_blank_config": {
         "is_block_running": False,
@@ -627,7 +628,7 @@ data = {
         </dict>
     </array>
 </dict>
-</plist>""",  # noqa: E501
+</plist>""",
     "NetNewsWire": """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -730,7 +731,7 @@ data = {
     <key>UserAgent</key>
     <string>NetNewsWire (RSS Reader; https://netnewswire.com/)</string>
 </dict>
-</plist>""",  # noqa: E501
+</plist>""",
     "reordered_notifs_dict": {
         "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
             "name": "Test Notif 2",
@@ -826,6 +827,16 @@ data = {
     "reordered_goal_dict": {
         "Conquer world": False,
         "Debug USACO problem": True
+    },
+    "proper_apps_dict": {
+        "Trello": {
+            "path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe",
+            "icon_path": "C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\assets\\Square310x310Logo.scale-200.png"
+        },
+        "vivaldi": {
+            "path": "C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe",
+            "icon_path": f"C:\\Users\\llamaempire\\AppData\\Local\\Lento\\vivaldi.bmp"
+        }
     }
 }
 
@@ -848,3 +859,17 @@ class fake_image:
 class fake_rgb:
     def save(x):
         return True
+
+def fake_subprocess(cmd):
+    cases = {
+        "powershell \"Get-Process -FileVersionInfo -ErrorAction SilentlyContinue | Select-Object FileName\"": """     
+FileName   
+--------   
+C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe   
+C:\\Program Files\\WindowsApps\\45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa\\app\\Trello.exe   
+C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   
+C:\\Users\\llamaempire\\AppData\\Local\\Vivaldi\\Application\\vivaldi.exe   """,
+            "powershell \"(Get-AppxPackage -Name \"*Trello*\" | Get-AppxPackageManifest).package.applications.application.VisualElements.DefaultTile.Square310x310Logo\"": "assets\Square310x310Logo.png",
+            "powershell \"{Add-Type -AssemblyName System.Drawing\n[System.Drawing.Icon]::ExtractAssociatedIcon(\'{app_path}\').toBitmap().Save(\'{app_icon_path}\')command_string}\"": ""
+    }
+    return cases[cmd]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -105,6 +105,29 @@ data = {
             "theme": "automatic"
         }
     },
+    "bare_config_with_blocked_sites": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {
+                    "youtube.com": True,
+                    "twitter.com": True
+                },
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": {}
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
     "bare_config_with_apps": {
         "is_block_running": False,
         "cards": {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,82 @@
+data = {
+    "initial_blank_config": {
+        "is_block_running": False,
+        "cards": {},
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "bare_config": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": "0",
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "filled_config":  {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": "0",
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
+            },
+            "Llama Taming": {
+                "id": "e68d8993-ee30-4e3f-941b-43c074e2759c",
+                "name": "Llama Taming",
+                "emoji": "🦙",
+                "time": "5,400",
+                "hard_blocked_sites": {
+                    "twitter.com": True
+                },
+                "soft_blocked_sites": {
+                    "youtube.com": True
+                },
+                "hard_blocked_apps": {
+                    "NetNewsWire": True
+                },
+                "soft_blocked_apps": {
+                    "calibre": False
+                },
+                "notifications": {
+                    "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+                        "type": "popup",
+                        "blocked_visit_triggers": [],
+                        "associated_goals": [
+                            "Obtain llama"
+                        ],
+                        "time_interval_trigger": 900000,
+                        "text": "Work on %g",
+                        "audio_paths": {
+                            "Bloop": "/System/Library/Sounds/Bloop.aiff"
+                        }
+                    }
+                },
+                "goals": ["Obtain llama"]
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    }
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,6 +60,8 @@ data = {
                 },
                 "notifications": {
                     "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+                        "name": "Test Notif 1",
+                        "enabled": True,
                         "type": "popup",
                         "blocked_visit_triggers": [],
                         "associated_goals": [
@@ -188,6 +190,8 @@ data = {
                 "soft_blocked_apps": {},
                 "notifications": {
                     "a019868e-f43f-478f-8dcc-ba78c35525c4": {
+                        "name": "Test Notif 1",
+                        "enabled": True,
                         "type": "banner",
                         "blocked_visit_triggers": [
                             "youtube.com",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import os
+from lento.config import Config
 
 data = {
     "initial_blank_config": {
@@ -856,7 +857,7 @@ data = {
     "proper_apps_dict": {
         "Trello": {
             "path": str(os.path.join(
-                "C:",
+                Config.DRIVE_LETTER,
                 "Program Files",
                 "WindowsApps",
                 "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
@@ -864,7 +865,7 @@ data = {
                 "Trello.exe"
             )),
             "icon_path": str(os.path.join(
-                "C:",
+                Config.DRIVE_LETTER,
                 "Program Files",
                 "WindowsApps",
                 "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
@@ -878,7 +879,7 @@ data = {
         {
             "name": "Trello",
             "path": str(os.path.join(
-                "C:",
+                Config.DRIVE_LETTER,
                 "Program Files",
                 "WindowsApps",
                 "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
@@ -886,7 +887,7 @@ data = {
                 "Trello.exe"
             )),
             "icon_path": str(os.path.join(
-                "C:",
+                Config.DRIVE_LETTER,
                 "Program Files",
                 "WindowsApps",
                 "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
@@ -923,7 +924,7 @@ class fake_rgb:
 def fake_subprocess(cmd):
     correct_trello_path = "".join([
         str(os.path.join(
-            "C:",
+            Config.DRIVE_LETTER,
             "Program Files",
             "WindowsApps",
             "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -100,3 +100,13 @@ data = {
         }
     }
 }
+
+
+def fake_bundle_id(args):
+    app = args[-1]
+    cases = {
+        "/Applications/GRIS.app": b"unity.nomada studio.GRIS",
+        "/Applications/Scrivener.app": b"com.literatureandlatte.scrivener3",
+        "/Applications/NetNewsWire.app": b"com.ranchero.NetNewsWire-Evergreen"
+    }
+    return cases[app]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -216,6 +216,61 @@ data = {
             "theme": "automatic"
         }
     },
+    "bare_config_multiple_notif": {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {
+                    "a019868e-f43f-478f-8dcc-ba78c35525c4": {
+                        "name": "Test Notif 1",
+                        "enabled": True,
+                        "type": "banner",
+                        "blocked_visit_triggers": [
+                            "youtube.com",
+                            "twitter.com"
+                        ],
+                        "associated_goals": [
+                            "Debug USACO problem"
+                        ],
+                        "time_interval_trigger": None,
+                        "title": "Get back to %g!",
+                        "body": "Keep focused!",
+                        "audio_paths": {
+                            "reminder": "~/Desktop/reminder.mp3",
+                            "Frog": "/System/Library/Sounds/Frog.aiff"
+                        }
+                    },
+                    "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+                        "name": "Test Notif 2",
+                        "enabled": False,
+                        "type": "popup",
+                        "blocked_visit_triggers": [],
+                        "associated_goals": [
+                            "Create pet AI"
+                        ],
+                        "time_interval_trigger": 900000,
+                        "title": "Work on %g",
+                        "body": "Keep focused!",
+                        "audio_paths": {
+                            "Bloop": "/System/Library/Sounds/Bloop.aiff"
+                        }
+                    }
+                },
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
     "GRIS": """<?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -675,7 +730,76 @@ data = {
     <key>UserAgent</key>
     <string>NetNewsWire (RSS Reader; https://netnewswire.com/)</string>
 </dict>
-</plist>"""  # noqa: E501
+</plist>""",  # noqa: E501
+    "reordered_notifs_dict": {
+        "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+            "name": "Test Notif 2",
+            "enabled": False,
+            "type": "popup",
+            "blocked_visit_triggers": [],
+            "associated_goals": [
+                "Create pet AI"
+            ],
+            "time_interval_trigger": 900000,
+            "title": "Work on %g",
+            "body": "Keep focused!",
+            "audio_paths": {
+                "Bloop": "/System/Library/Sounds/Bloop.aiff"
+            }
+        },
+        "a019868e-f43f-478f-8dcc-ba78c35525c4": {
+            "name": "Test Notif 1",
+            "enabled": True,
+            "type": "banner",
+            "blocked_visit_triggers": [
+                "youtube.com",
+                "twitter.com"
+            ],
+            "associated_goals": [
+                "Debug USACO problem"
+            ],
+            "time_interval_trigger": None,
+            "title": "Get back to %g!",
+            "body": "Keep focused!",
+            "audio_paths": {
+                "reminder": "~/Desktop/reminder.mp3",
+                "Frog": "/System/Library/Sounds/Frog.aiff"
+            }
+        }
+    },
+    "deleted_notifs_dict": {
+        "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+            "name": "Test Notif 2",
+            "enabled": False,
+            "type": "popup",
+            "blocked_visit_triggers": [],
+            "associated_goals": [
+                "Create pet AI"
+            ],
+            "time_interval_trigger": 900000,
+            "title": "Work on %g",
+            "body": "Keep focused!",
+            "audio_paths": {
+                "Bloop": "/System/Library/Sounds/Bloop.aiff"
+            }
+        }
+    },
+    "flawed_notifs_dict": {
+        "2d189b37-6eaf-478f-a5ab-e19c9dab5738": {
+            "name": "Test Notif 2",
+            "enabled": False,
+            "blocked_visit_triggers": [],
+            "associated_goals": [
+                "Create pet AI"
+            ],
+            "time_interval_trigger": 900000,
+            "title": "Work on %g",
+            "body": "Keep focused!",
+            "audio_paths": {
+                "Bloop": "/System/Library/Sounds/Bloop.aiff"
+            }
+        }
+    }
 }
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,7 +13,7 @@ data = {
                 "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
                 "name": "Untitled Card",
                 "emoji": "😃",
-                "time": "0",
+                "time": 0,
                 "hard_blocked_sites": {},
                 "soft_blocked_sites": {},
                 "hard_blocked_apps": {},
@@ -33,7 +33,7 @@ data = {
                 "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
                 "name": "Untitled Card",
                 "emoji": "😃",
-                "time": "0",
+                "time": 0,
                 "hard_blocked_sites": {},
                 "soft_blocked_sites": {},
                 "hard_blocked_apps": {},
@@ -45,7 +45,7 @@ data = {
                 "id": "e68d8993-ee30-4e3f-941b-43c074e2759c",
                 "name": "Llama Taming",
                 "emoji": "🦙",
-                "time": "5,400",
+                "time": 5400,
                 "hard_blocked_sites": {
                     "twitter.com": True
                 },
@@ -73,6 +73,26 @@ data = {
                     }
                 },
                 "goals": ["Obtain llama"]
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    },
+    "updated_bare_config": {
+        "is_block_running": False,
+        "cards": {
+            "World Domination": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "World Domination",
+                "emoji": "😃",
+                "time": 0,
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
             }
         },
         "application_settings": {

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -823,3 +823,68 @@ def test_add_goal_rejects_flawed_data(monkeypatch, tmp_path):
             42,
             "Conquer world"
         )
+
+
+def test_update_goal_list_reorders_correctly(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config_with_goals"], settings_json)
+
+    CardsManagement.update_goal_list(
+        "Untitled Card",
+        helpers.data["reordered_goal_dict"]
+    )
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    card_goals_dict = new_settings["cards"]["Untitled Card"]["goals"]
+
+    assert "Conquer world" in card_goals_dict
+    assert "Debug USACO problem" in card_goals_dict
+    assert card_goals_dict["Conquer world"] is False
+    assert card_goals_dict["Debug USACO problem"] is True
+
+
+def test_update_goal_list_deletes_correctly(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config_with_goals"], settings_json)
+
+    CardsManagement.update_goal_list(
+        "Untitled Card",
+        {"Conquer world": False}
+    )
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    card_goals_dict = new_settings["cards"]["Untitled Card"]["goals"]
+
+    assert "Conquer world" in card_goals_dict
+    assert "Debug USACO problem" not in card_goals_dict
+    assert card_goals_dict["Conquer world"] is False
+    assert list(card_goals_dict.keys()) == ["Conquer world"]
+
+
+def test_update_goal_list_rejects_flawed_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config_with_goals"], settings_json)
+
+    with pytest.raises(Exception):
+        CardsManagement.update_goal_list(
+            "Untitled Card",
+            "Llama"
+        )
+    with pytest.raises(Exception):
+        CardsManagement.update_goal_list(
+            "Llama",
+            helpers.data["reordered_goal_dict"]
+        )

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -297,6 +297,56 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     }
 
 
+def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    CardsManagement.add_to_app_blocklists(
+        "Untitled Card",
+        "hard_blocked_apps",
+        [
+            "Notepad",
+            "Vivaldi",
+            "Raindrop.io"
+        ]
+    )
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    hb_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
+
+    assert "Notepad" in hb_list
+    assert "Vivaldi" in hb_list
+    assert "Raindrop.io" in hb_list
+
+    assert hb_list["Notepad"] == {
+        "enabled": True,
+        "app_icon_path": os.path.join(
+            os.path.expanduser("~"),
+            "Library/Application Support/Lento/GRIS.jpg"
+        )
+    }
+    assert hb_list["Vivaldi"] == {
+        "enabled": True,
+        "app_icon_path": os.path.join(
+            os.path.expanduser("~"),
+            "Library/Application Support/Lento/Scrivener.jpg"
+        )
+    }
+    assert hb_list["Raindrop.io"] == {
+        "enabled": True,
+        "app_icon_path": os.path.join(
+            os.path.expanduser("~"),
+            "Library/Application Support/Lento/NetNewsWire.jpg"
+        )
+    }
+
+
 def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -338,7 +338,7 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
 def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     appdata_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
-    appdata_dict['vivaldi']['path'] = os.path.join(
+    appdata_dict["vivaldi"]["path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",
@@ -346,7 +346,7 @@ def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
         "Application",
         "vivaldi.exe"
     )
-    appdata_dict['vivaldi']['icon_path'] = os.path.join(
+    appdata_dict["vivaldi"]["icon_path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",
@@ -359,8 +359,8 @@ def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config"], settings_json)
 
-    apps_to_add = copy.deepcopy(helpers.data['apps_to_add'])
-    apps_to_add[1]['path'] = os.path.join(
+    apps_to_add = copy.deepcopy(helpers.data["apps_to_add"])
+    apps_to_add[1]["path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",
@@ -368,7 +368,7 @@ def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
         "Application",
         "vivaldi.exe"
     )
-    apps_to_add[1]['icon_path'] = os.path.join(
+    apps_to_add[1]["icon_path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -337,24 +337,55 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
 
 def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    appdata_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
+    appdata_dict['vivaldi']['path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Vivaldi",
+        "Application",
+        "vivaldi.exe"
+    )
+    appdata_dict['vivaldi']['icon_path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Lento",
+        "vivaldi.bmp"
+    )
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config"], settings_json)
 
+    apps_to_add = copy.deepcopy(helpers.data['apps_to_add'])
+    apps_to_add[1]['path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Vivaldi",
+        "Application",
+        "vivaldi.exe"
+    )
+    apps_to_add[1]['icon_path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Lento",
+        "vivaldi.bmp"
+    )
+
     CardsManagement.add_to_app_blocklists(
         "Untitled Card",
         "hard_blocked_apps",
-        helpers.data['apps_to_add']
+        apps_to_add
     )
 
     with open(path, "r", encoding="UTF-8") as settings_json:
         new_settings = json.load(settings_json)
 
     hb_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
-
-    appdata_dict = helpers.data["proper_apps_dict"]
 
     assert "Trello" in hb_list
     assert "vivaldi" in hb_list

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -368,6 +368,7 @@ def test_add_notification_works_correctly(monkeypatch, tmp_path):
         ["Debug USACO problem"],
         None,
         "Get back to %g!",
+        "Keep focused!",
         {
             "reminder": "~/Desktop/reminder.mp3",
             "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -406,6 +407,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Debug USACO problem"],
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -419,6 +421,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Debug USACO problem"],
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -435,6 +438,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Debug USACO problem"],
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -451,6 +455,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Debug USACO problem"],
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -464,6 +469,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             "Debug USACO problem",
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -480,6 +486,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Amass gigantic fleet of llamas"],
             None,
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -496,6 +503,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["Debug USACO problem"],
             "Llama",
             "Get back to %g!",
+            "Keep focused!",
             {
                 "reminder": "~/Desktop/reminder.mp3",
                 "Frog": "/System/Library/Sounds/Frog.aiff"
@@ -503,7 +511,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
         )
     with pytest.raises(
                 Exception,
-                match="Notification text is not a string!"
+                match="Notification title is not a string!"
             ):
         CardsManagement.add_notification(
             "Untitled Card",
@@ -511,6 +519,24 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
             ["youtube.com", "twitter.com"],
             ["Debug USACO problem"],
             None,
+            42,
+            "Keep focused!",
+            {
+                "reminder": "~/Desktop/reminder.mp3",
+                "Frog": "/System/Library/Sounds/Frog.aiff"
+            }
+        )
+    with pytest.raises(
+                Exception,
+                match="Notification body is not a string!"
+            ):
+        CardsManagement.add_notification(
+            "Untitled Card",
+            "banner",
+            ["youtube.com", "twitter.com"],
+            ["Debug USACO problem"],
+            None,
+            "Get back to %g!",
             42,
             {
                 "reminder": "~/Desktop/reminder.mp3",

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -38,3 +38,16 @@ def test_read_cards_returns_correct_data(monkeypatch, tmp_path):
     assert expected_result == cards
 
 
+def test_delete_card_works_correctly(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["filled_config"], settings_json)
+
+    CardsManagement.delete_card("Llama Taming")
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    expected_result = helpers.data["bare_config"]
+    assert expected_result == new_settings

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -362,6 +362,8 @@ def test_add_notification_works_correctly(monkeypatch, tmp_path):
         json.dump(data, settings_json)
 
     CardsManagement.add_notification(
+        "Test Notif 1",
+        True,
         "Untitled Card",
         "banner",
         ["youtube.com", "twitter.com"],
@@ -399,8 +401,42 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(data, settings_json)
 
+    with pytest.raises(Exception, match="Name must be a string!"):
+        CardsManagement.add_notification(
+            42,
+            True,
+            "Untitled Card",
+            "banner",
+            ["youtube.com", "twitter.com"],
+            ["Debug USACO problem"],
+            None,
+            "Get back to %g!",
+            "Keep focused!",
+            {
+                "reminder": "~/Desktop/reminder.mp3",
+                "Frog": "/System/Library/Sounds/Frog.aiff"
+            }
+        )
+    with pytest.raises(Exception, match="Enabled must be a boolean!"):
+        CardsManagement.add_notification(
+            "Test Notif 1",
+            "Llama",
+            "Untitled Card",
+            "banner",
+            ["youtube.com", "twitter.com"],
+            ["Debug USACO problem"],
+            None,
+            "Get back to %g!",
+            "Keep focused!",
+            {
+                "reminder": "~/Desktop/reminder.mp3",
+                "Frog": "/System/Library/Sounds/Frog.aiff"
+            }
+        )
     with pytest.raises(KeyError):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Llama",
             "banner",
             ["youtube.com", "twitter.com"],
@@ -415,6 +451,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
         )
     with pytest.raises(Exception, match="Notification type not valid!"):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "llama_army",
             ["youtube.com", "twitter.com"],
@@ -432,6 +470,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Blocked visit triggers is not a list!"
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             "youtube.com",
@@ -449,6 +489,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Blocked visit triggers 'thesephist.com' not found in blocklists!"  # noqa: E501
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["thesephist.com"],
@@ -463,6 +505,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
         )
     with pytest.raises(Exception, match="Associated goals is not a list!"):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["youtube.com", "twitter.com"],
@@ -480,6 +524,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Associated goals not found in goal list!"
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["youtube.com", "twitter.com"],
@@ -497,6 +543,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Timer interval trigger is not an integer or None!"
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["youtube.com", "twitter.com"],
@@ -514,6 +562,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Notification title is not a string!"
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["youtube.com", "twitter.com"],
@@ -531,6 +581,8 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 match="Notification body is not a string!"
             ):
         CardsManagement.add_notification(
+            "Test Notif 1",
+            True,
             "Untitled Card",
             "banner",
             ["youtube.com", "twitter.com"],

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -299,7 +299,10 @@ def test_update_site_blocklists_works_correctly(monkeypatch, tmp_path):
     assert "twitter.com" in cards_dict["hard_blocked_sites"]
     assert cards_dict["hard_blocked_sites"]["youtube.com"] is True
     assert cards_dict["hard_blocked_sites"]["twitter.com"] is False
-    assert list(cards_dict["hard_blocked_sites"].keys()) == ["youtube.com", "twitter.com"]
+    assert list(cards_dict["hard_blocked_sites"].keys()) == [
+        "youtube.com",
+        "twitter.com"
+    ]
 
 
 def test_update_site_blocklists_rejects_flawed_data(monkeypatch, tmp_path):

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -335,7 +335,6 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     }
 
 
-@pytest.mark.skip
 def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     monkeypatch.setattr(platform, "system", lambda: "Windows")

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -1,0 +1,54 @@
+import json
+import os
+import uuid
+import lento.common.cards_management as CardsManagement
+
+
+def test_create_card_uses_correct_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    monkeypatch.setattr(
+        uuid.UUID,
+        "hex",
+        "b0244f7e-8369-49f9-89b4-73811eba3a0e"
+    )
+
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    initial_config = {
+        "is_block_running": False,
+        "cards": {},
+        "application_settings": {
+            "theme": "automatic"
+        }
+    }
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        settings = json.dump(initial_config, settings_json)
+
+    expected_config = {
+        "is_block_running": False,
+        "cards": {
+            "Untitled Card": {
+                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
+                "name": "Untitled Card",
+                "emoji": "😃",
+                "time": "0",
+                "hard_blocked_sites": {},
+                "soft_blocked_sites": {},
+                "hard_blocked_apps": {},
+                "soft_blocked_apps": {},
+                "notifications": {},
+                "goals": []
+            }
+        },
+        "application_settings": {
+            "theme": "automatic"
+        }
+    }
+
+    CardsManagement.create_card()
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        settings = json.load(settings_json)
+
+    assert settings == expected_config

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -126,5 +126,32 @@ def test_update_metdata_denies_incorrect_card_name_or_field(
             "World Domination"
         )
 
-# test_update_metadata_denies_restricted_field_change
-# test_update_metadata_validates_time_as_number
+
+def test_update_metadata_denies_restricted_field_change(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(Exception):
+        CardsManagement.update_metadata(
+            "Untitled Card",
+            "id",
+            "5d15e4f7-e08e-4f91-9713-fa46f13a9761"
+        )
+
+
+def test_update_metadata_validates_time_as_number(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(ValueError):
+        CardsManagement.update_metadata(
+            "Untitled Card",
+            "time",
+            "Eternal Reign of the Llama Lords"
+        )

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -240,6 +240,9 @@ def test_update_site_blocklists_denies_restricted_field_change(
 
 def test_update_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    application_data_path = os.path.join(tmp_path,  "Library/Application Support/Lento")
+    os.makedirs(application_data_path)
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.setattr(subprocess, "check_output", helpers.fake_bundle_id)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
@@ -247,7 +250,7 @@ def test_update_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config"], settings_json)
 
-    CardsManagement.update_app_blocklists(
+    CardsManagement.add_to_app_blocklists(
         "Untitled Card",
         "hard_blocked_apps",
         [
@@ -260,11 +263,24 @@ def test_update_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     with open(path, "r", encoding="UTF-8") as settings_json:
         new_settings = json.load(settings_json)
 
-    list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
+    hardblocked_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
 
-    assert "unity.nomada studio.GRIS" in list
-    assert "com.literatureandlatte.scrivener3" in list
-    assert "com.ranchero.NetNewsWire-Evergreen" in list
-    assert list["unity.nomada studio.GRIS"] is True
-    assert list["com.literatureandlatte.scrivener3"] is True
-    assert list["com.ranchero.NetNewsWire-Evergreen"] is True
+    assert "GRIS" in hardblocked_list
+    assert "Scrivener" in hardblocked_list
+    assert "NetNewsWire" in hardblocked_list
+
+    assert hardblocked_list["GRIS"] == {
+        "enabled": True,
+        "bundle_id": "unity.nomada studio.GRIS",
+        "app_icon_path": os.path.join(os.path.expanduser("~"),  "Library/Application Support/Lento/GRIS.jpg")
+    }
+    assert hardblocked_list["Scrivener"] == {
+        "enabled": True,
+        "bundle_id": "com.literatureandlatte.scrivener3",
+        "app_icon_path": os.path.join(os.path.expanduser("~"),  "Library/Application Support/Lento/Scrivener.jpg")
+    }
+    assert hardblocked_list["NetNewsWire"] == {
+        "enabled": True,
+        "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
+        "app_icon_path": os.path.join(os.path.expanduser("~"),  "Library/Application Support/Lento/NetNewsWire.jpg")
+    }

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -424,7 +424,7 @@ def test_add_notification_works_correctly(monkeypatch, tmp_path):
     data = copy.deepcopy(helpers.data["bare_config"])
     data["cards"]["Untitled Card"]["hard_blocked_sites"]["youtube.com"] = True
     data["cards"]["Untitled Card"]["hard_blocked_sites"]["twitter.com"] = True
-    data["cards"]["Untitled Card"]["goals"].append("Debug USACO problem")
+    data["cards"]["Untitled Card"]["goals"]["Debug USACO problem"] = True
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(data, settings_json)
 
@@ -464,7 +464,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
     data = copy.deepcopy(helpers.data["bare_config"])
     data["cards"]["Untitled Card"]["hard_blocked_sites"]["youtube.com"] = True
     data["cards"]["Untitled Card"]["hard_blocked_sites"]["twitter.com"] = True
-    data["cards"]["Untitled Card"]["goals"].append("Debug USACO problem")
+    data["cards"]["Untitled Card"]["goals"]["Debug USACO problem"] = True
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(data, settings_json)
 
@@ -783,4 +783,43 @@ def test_update_notification_list_rejects_flawed_data(monkeypatch, tmp_path):
         CardsManagement.update_notification_list(
             "Untitled Card",
             helpers.data["flawed_notifs_dict"]
+        )
+
+
+def test_add_goal_works_correctly(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    CardsManagement.add_goal(
+        "Untitled Card",
+        "Conquer world"
+    )
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    new_goals_dict = new_settings["cards"]["Untitled Card"]["goals"]
+    assert "Conquer world" in new_goals_dict
+    assert new_goals_dict["Conquer world"] is False
+
+
+def test_add_goal_rejects_flawed_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(Exception, match="Goal to add is not string!"):
+        CardsManagement.add_goal(
+            "Untitled Card",
+            42
+        )
+    with pytest.raises(KeyError):
+        CardsManagement.add_goal(
+            42,
+            "Conquer world"
         )

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -346,11 +346,7 @@ def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     CardsManagement.add_to_app_blocklists(
         "Untitled Card",
         "hard_blocked_apps",
-        [
-            "Notepad",
-            "AutoHotKey",
-            "Discord"
-        ]
+        helpers.data['apps_to_add']
     )
 
     with open(path, "r", encoding="UTF-8") as settings_json:
@@ -358,9 +354,21 @@ def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
 
     hb_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
 
-    assert "Notepad" in hb_list
-    assert "AutoHotKey" in hb_list
-    assert "Discord" in hb_list
+    appdata_dict = helpers.data["proper_apps_dict"]
+
+    assert "Trello" in hb_list
+    assert "vivaldi" in hb_list
+
+    assert hb_list["Trello"] == {
+        "enabled": True,
+        "path": appdata_dict["Trello"]["path"],
+        "app_icon_path": appdata_dict["Trello"]["icon_path"],
+    }
+    assert hb_list["vivaldi"] == {
+        "enabled": True,
+        "path": appdata_dict["vivaldi"]["path"],
+        "app_icon_path": appdata_dict["vivaldi"]["icon_path"],
+    }
 
 
 def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 import lento.common.cards_management as CardsManagement
+from tests import helpers
 
 
 def test_create_card_uses_correct_data(monkeypatch, tmp_path):
@@ -14,41 +15,26 @@ def test_create_card_uses_correct_data(monkeypatch, tmp_path):
 
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
 
-    initial_config = {
-        "is_block_running": False,
-        "cards": {},
-        "application_settings": {
-            "theme": "automatic"
-        }
-    }
-
     with open(path, "w", encoding="UTF-8") as settings_json:
-        settings = json.dump(initial_config, settings_json)
-
-    expected_config = {
-        "is_block_running": False,
-        "cards": {
-            "Untitled Card": {
-                "id": "b0244f7e-8369-49f9-89b4-73811eba3a0e",
-                "name": "Untitled Card",
-                "emoji": "😃",
-                "time": "0",
-                "hard_blocked_sites": {},
-                "soft_blocked_sites": {},
-                "hard_blocked_apps": {},
-                "soft_blocked_apps": {},
-                "notifications": {},
-                "goals": []
-            }
-        },
-        "application_settings": {
-            "theme": "automatic"
-        }
-    }
+        json.dump(helpers.data["initial_blank_config"], settings_json)
 
     CardsManagement.create_card()
 
     with open(path, "r", encoding="UTF-8") as settings_json:
         settings = json.load(settings_json)
 
-    assert settings == expected_config
+    assert settings == helpers.data["bare_config"]
+
+
+def test_read_cards_returns_correct_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["filled_config"], settings_json)
+
+    expected_result = helpers.data["filled_config"]["cards"]
+    cards = CardsManagement.read_cards()
+    assert expected_result == cards
+
+

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -297,56 +297,6 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     }
 
 
-def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    monkeypatch.setattr(platform, "system", lambda: "Windows")
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
-
-    CardsManagement.add_to_app_blocklists(
-        "Untitled Card",
-        "hard_blocked_apps",
-        [
-            "Notepad",
-            "Vivaldi",
-            "Raindrop.io"
-        ]
-    )
-
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        new_settings = json.load(settings_json)
-
-    hb_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
-
-    assert "Notepad" in hb_list
-    assert "Vivaldi" in hb_list
-    assert "Raindrop.io" in hb_list
-
-    assert hb_list["Notepad"] == {
-        "enabled": True,
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/GRIS.jpg"
-        )
-    }
-    assert hb_list["Vivaldi"] == {
-        "enabled": True,
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/Scrivener.jpg"
-        )
-    }
-    assert hb_list["Raindrop.io"] == {
-        "enabled": True,
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/NetNewsWire.jpg"
-        )
-    }
-
-
 def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -273,6 +273,7 @@ def test_update_site_blocklists_works_correctly(monkeypatch, tmp_path):
     assert "twitter.com" in cards_dict["hard_blocked_sites"]
     assert cards_dict["hard_blocked_sites"]["youtube.com"] is True
     assert cards_dict["hard_blocked_sites"]["twitter.com"] is False
+    assert list(cards_dict["hard_blocked_sites"].keys()) == ["youtube.com", "twitter.com"]
 
 
 def test_update_site_blocklists_rejects_flawed_data(monkeypatch, tmp_path):
@@ -404,6 +405,7 @@ def test_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
             "Library/Application Support/Lento/NetNewsWire.jpg"
         )
     }
+    assert list(hb_list.keys()) == ["GRIS", "Scrivener", "NetNewsWire"]
 
 
 def test_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
@@ -472,6 +474,8 @@ def test_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
         "app_icon_path": appdata_dict["vivaldi"]["icon_path"],
     }
 
+    assert list(hb_list.keys()) == ["Trello", "vivaldi"]
+
 
 def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
@@ -490,8 +494,9 @@ def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
         new_settings = json.load(settings_json)
 
     new_hblist = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
-    correct_cards = helpers.data["bare_config_reordered_apps"]["cards"]
-    assert new_hblist == correct_cards["Untitled Card"]["hard_blocked_apps"]
+    correct_hblist = helpers.data["bare_config_reordered_apps"]["cards"]["Untitled Card"]["hard_blocked_apps"]  # noqa: E501
+    assert new_hblist == correct_hblist
+    assert list(new_hblist.keys()) == list(correct_hblist.keys())
 
 
 def test_update_app_blocklists_rejects_incorrect(monkeypatch, tmp_path):

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -377,12 +377,11 @@ def test_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
         plist_file.write(helpers.data[file])
         plist_file.close()
 
-    if platform.system() == "Windows":
-        monkeypatch.setattr(
-            Config,
-            "MACOS_APPLICATION_FOLDER",
-            os.path.join(tmp_path, folders["apps_folder"])
-        )
+    monkeypatch.setattr(
+        Config,
+        "MACOS_APPLICATION_FOLDER",
+        os.path.join(tmp_path, folders["apps_folder"])
+    )
     monkeypatch.setattr(Image, "open", lambda x: helpers.fake_image)
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.setattr(subprocess, "check_output", helpers.fake_bundle_id)

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -161,14 +161,14 @@ def test_update_metadata_validates_time_as_number(monkeypatch, tmp_path):
         )
 
 
-def test_update_site_blocklists_adds_data(monkeypatch, tmp_path):
+def test_add_to_site_blocklists_adds_data(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
 
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config"], settings_json)
 
-    CardsManagement.update_site_blocklists(
+    CardsManagement.add_to_site_blocklists(
         "Untitled Card",
         "hard_blocked_sites",
         "https://youtube.com"
@@ -182,7 +182,7 @@ def test_update_site_blocklists_adds_data(monkeypatch, tmp_path):
     assert cards_dict["hard_blocked_sites"]["https://youtube.com"] is True
 
 
-def test_update_site_blocklists_denies_malformed_data(monkeypatch, tmp_path):
+def test_add_to_site_blocklists_denies_malformed_data(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
 
@@ -190,14 +190,14 @@ def test_update_site_blocklists_denies_malformed_data(monkeypatch, tmp_path):
         json.dump(helpers.data["bare_config"], settings_json)
 
     with pytest.raises(Exception, match="URL not valid!"):
-        CardsManagement.update_site_blocklists(
+        CardsManagement.add_to_site_blocklists(
             "Untitled Card",
             "hard_blocked_sites",
             "llama"
         )
 
 
-def test_update_site_blocklists_denies_incorrect_card_or_list_name(
+def test_add_to_site_blocklists_denies_incorrect_card_or_list_name(
             monkeypatch,
             tmp_path
         ):
@@ -208,21 +208,21 @@ def test_update_site_blocklists_denies_incorrect_card_or_list_name(
         json.dump(helpers.data["bare_config"], settings_json)
 
     with pytest.raises(KeyError):
-        CardsManagement.update_site_blocklists(
+        CardsManagement.add_to_site_blocklists(
             "Untitled Card",
             "hard_blocked_NIGHTS",
             "https://youtube.com"
         )
 
     with pytest.raises(KeyError):
-        CardsManagement.update_site_blocklists(
+        CardsManagement.add_to_site_blocklists(
             "Llama Taming",
             "hard_blocked_sites",
             "https://youtube.com"
         )
 
 
-def test_update_site_blocklists_denies_restricted_field_change(
+def test_add_to_site_blocklists_denies_restricted_field_change(
             monkeypatch,
             tmp_path
         ):
@@ -233,7 +233,7 @@ def test_update_site_blocklists_denies_restricted_field_change(
         json.dump(helpers.data["bare_config"], settings_json)
 
     with pytest.raises(Exception, match="Card field is restricted!"):
-        CardsManagement.update_site_blocklists(
+        CardsManagement.add_to_site_blocklists(
             "Untitled Card",
             "hard_blocked_apps",
             "org.zotero.zotero"

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -335,6 +335,34 @@ def test_update_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     }
 
 
+def test_update_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    CardsManagement.add_to_app_blocklists(
+        "Untitled Card",
+        "hard_blocked_apps",
+        [
+            "Notepad",
+            "AutoHotKey",
+            "Discord"
+        ]
+    )
+
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    hb_list = new_settings["cards"]["Untitled Card"]["hard_blocked_apps"]
+
+    assert "Notepad" in hb_list
+    assert "AutoHotKey" in hb_list
+    assert "Discord" in hb_list
+
+
 def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
     path = os.path.join(os.path.expanduser("~"), "lentosettings.json")

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -155,3 +155,83 @@ def test_update_metadata_validates_time_as_number(monkeypatch, tmp_path):
             "time",
             "Eternal Reign of the Llama Lords"
         )
+
+
+def test_update_site_blocklists_correctly_adds_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    CardsManagement.update_site_blocklists(
+        "Untitled Card",
+        "hard_blocked_sites",
+        "https://youtube.com"
+    )
+    with open(path, "r", encoding="UTF-8") as settings_json:
+        new_settings = json.load(settings_json)
+
+    cards_dict = new_settings["cards"]["Untitled Card"]
+
+    assert "https://youtube.com" in cards_dict["hard_blocked_sites"]
+    assert cards_dict["hard_blocked_sites"]["https://youtube.com"] is True
+
+
+def test_update_site_blocklists_denies_malformed_data(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(Exception, match="URL not valid!"):
+        CardsManagement.update_site_blocklists(
+            "Untitled Card",
+            "hard_blocked_sites",
+            "llama"
+        )
+
+
+def test_update_site_blocklists_denies_incorrect_card_or_list_name(
+            monkeypatch,
+            tmp_path
+        ):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(KeyError):
+        CardsManagement.update_site_blocklists(
+            "Untitled Card",
+            "hard_blocked_NIGHTS",
+            "https://youtube.com"
+        )
+
+    with pytest.raises(KeyError):
+        CardsManagement.update_site_blocklists(
+            "Llama Taming",
+            "hard_blocked_sites",
+            "https://youtube.com"
+        )
+
+
+def test_update_site_blocklists_denies_restricted_field_change(
+            monkeypatch,
+            tmp_path
+        ):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+
+    with open(path, "w", encoding="UTF-8") as settings_json:
+        json.dump(helpers.data["bare_config"], settings_json)
+
+    with pytest.raises(Exception, match="Card field is restricted!"):
+        CardsManagement.update_site_blocklists(
+            "Untitled Card",
+            "hard_blocked_apps",
+            "org.zotero.zotero"
+        )
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_get_apps_windows(monkeypatch, tmp_path):
     apps = utils.get_apps()
 
     proper_apps_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
-    proper_apps_dict['vivaldi']['path'] = os.path.join(
+    proper_apps_dict["vivaldi"]["path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",
@@ -30,7 +30,7 @@ def test_get_apps_windows(monkeypatch, tmp_path):
         "Application",
         "vivaldi.exe"
     )
-    proper_apps_dict['vivaldi']['icon_path'] = os.path.join(
+    proper_apps_dict["vivaldi"]["icon_path"] = os.path.join(
         os.path.expanduser("~"),
         "AppData",
         "Local",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+from lento import utils
+
+
+def test_remove_dupes_blanks_and_whitespace():
+    test_list = ["llamas   ", "are", "cool", "", "cool", "llamas", ""]
+    new_list = utils.remove_dupes_blanks_and_whitespace(test_list)
+
+    assert new_list == ["llamas", "are", "cool"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,14 @@ def test_get_apps_windows(monkeypatch, tmp_path):
     apps = utils.get_apps()
 
     proper_apps_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
+    proper_apps_dict['vivaldi']['path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Vivaldi",
+        "Application",
+        "vivaldi.exe"
+    )
     proper_apps_dict['vivaldi']['icon_path'] = os.path.join(
         os.path.expanduser("~"),
         "AppData",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-import copy
-import json
 import os
 import platform
 import subprocess

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,21 +25,40 @@ def test_get_apps_windows(monkeypatch, tmp_path):
 
     apps = utils.get_apps()
 
-    proper_apps_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
-    proper_apps_dict["vivaldi"]["path"] = os.path.join(
-        os.path.expanduser("~"),
-        "AppData",
-        "Local",
-        "Vivaldi",
-        "Application",
-        "vivaldi.exe"
-    )
-    proper_apps_dict["vivaldi"]["icon_path"] = os.path.join(
-        os.path.expanduser("~"),
-        "AppData",
-        "Local",
-        "Lento",
-        "vivaldi.bmp"
-    )
-
-    assert apps == proper_apps_dict
+    assert apps == {
+        "Trello": {
+            "path": str(os.path.join(
+                Config.DRIVE_LETTER,
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "app",
+                "Trello.exe"
+            )),
+            "icon_path": str(os.path.join(
+                Config.DRIVE_LETTER,
+                "Program Files",
+                "WindowsApps",
+                "45273LiamForsyth.PawsforTrello_2.12.5.0_x64__7pb5ddty8z1pa",
+                "assets",
+                "Square310x310Logo.scale-200.png"
+            ))
+        },
+        "vivaldi": {
+            "path": os.path.join(
+                os.path.expanduser("~"),
+                "AppData",
+                "Local",
+                "Vivaldi",
+                "Application",
+                "vivaldi.exe"
+            ),
+            "icon_path": os.path.join(
+                os.path.expanduser("~"),
+                "AppData",
+                "Local",
+                "Lento",
+                "vivaldi.bmp"
+            )
+        }
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,9 @@
+import copy
+import os
+import platform
+import subprocess
 from lento import utils
+from tests import helpers
 
 
 def test_remove_dupes_blanks_and_whitespace():
@@ -6,3 +11,23 @@ def test_remove_dupes_blanks_and_whitespace():
     new_list = utils.remove_dupes_blanks_and_whitespace(test_list)
 
     assert new_list == ["llamas", "are", "cool"]
+
+
+def test_get_apps_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(subprocess, "getoutput", helpers.fake_subprocess)
+    monkeypatch.setattr(subprocess, "call", lambda x, shell="": "")
+
+    apps = utils.get_apps()
+
+    proper_apps_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
+    proper_apps_dict['vivaldi']['icon_path'] = os.path.join(
+        os.path.expanduser("~"),
+        "AppData",
+        "Local",
+        "Lento",
+        "vivaldi.bmp"
+    )
+
+    assert apps == proper_apps_dict

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import copy
+import json
 import os
 import platform
 import subprocess
+from lento.config import Config
 from lento import utils
 from tests import helpers
 
@@ -15,6 +17,8 @@ def test_remove_dupes_blanks_and_whitespace():
 
 def test_get_apps_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
+    if platform.system() == "Darwin":
+        monkeypatch.setattr(Config, "DRIVE_LETTER", "C:/")
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     monkeypatch.setattr(subprocess, "getoutput", helpers.fake_subprocess)
     monkeypatch.setattr(subprocess, "call", lambda x, shell="": "")


### PR DESCRIPTION
**Added the following:**
- `cards_management`
    - `create_card()`
    - `read_cards()`
    - `delete_cards()`
    - `update_metadata()`
    - `add_to_site_blocklists()`
    - `update_site_blocklists()`
    - `add_to_app_blocklists()`
    - `update_app_blocklists()`
    - `add_notification()`
    - `update_notification_list()`
    - `add_goals()`
    - `update_goal_list()`
- `utils`
    - `get_apps()`
    - `is_url()`
    - `remove_dupes_blanks_and_whitespace()`
- `cli.py` - not production code but useful for live-ammo testing
- docs/lento-log - updated for the recent misadventures of this PR

The above have tests and have also gone through live-ammo testing.

**Dependencies changed:**
- Added `pillow>=9.0.0` - needed to convert ICNS to JPG for macOS app icon display
- Commented out `watchdog>=2.1.6`, `pyobjc>=8.1`, and `psutil>=5.9.0` - will likely need later but unnecessary for now

**Non-ideal but non-dealbreakers:** 
- `utils.get_apps()` - switch between `Path` and `str` a lot without clear structure of when which is used
- `cards_management`, `utils` - lack of consistent docstrings and typehints
- `Config` - has a duplicate function from `utils`, but we can't use the `utils` one because of circular imports
- docs - main docs file is slightly out of date and the log is a bit verbose, but both of those we can fix up later