### PR TITLE
fix: prevent GUI freezing on daemon launch

### DIFF
--- a/lento/common/_block_controller.py
+++ b/lento/common/_block_controller.py
@@ -44,11 +44,11 @@ class BlockController(ABC):
         CardsManagement.deactivate_block_in_settings()
         return self.daemon_takedown()
 
-    def get_remaining_block_time(self):
+    def get_remaining_block_time(self, time_preset):
         try:
             timer = BlockTimer.get(BlockTimer.website == "_main")
         except DoesNotExist:
-            return 0
+            return time_preset
         db.close()
 
         data = pickle.loads(timer.data)

--- a/lento/common/macos_block_controller.py
+++ b/lento/common/macos_block_controller.py
@@ -8,21 +8,20 @@ class macOSBlockController(BlockController):
         super().__init__()
 
     def daemon_launch(self, bundled_binary_path, card_to_use, lasts_for):
-        commands = [
-            " ".join([
-                f"cp \"{bundled_binary_path}\"",
-                f"\"{Config.DAEMON_BINARY_PATH}\""
-            ]),
-            " ".join([
-                f"\"{str(Config.DAEMON_BINARY_PATH)}\"",
-                f"\"{card_to_use}\"",
-                str(lasts_for)
-            ])
+        copycmd = " ".join([
+            "cp",
+            f"\"{bundled_binary_path}\"",
+            f"\"{Config.DAEMON_BINARY_PATH}\""
+        ])
+        daemon_launch_cmd = [
+            str(Config.DAEMON_BINARY_PATH),
+            str(card_to_use),
+            str(lasts_for)
         ]
-        result = []
-        for cmd in commands:
-            result.append(subprocess.call(cmd, shell=True))
-        return result
+        results = []
+        results.append(subprocess.call(copycmd, shell=True))
+        results.append(subprocess.Popen(daemon_launch_cmd, shell=False))
+        return results
 
     def daemon_takedown(self):
         cmd = (f"rm -f \"{Config.DAEMON_BINARY_PATH}\"")

--- a/lento/common/windows_block_controller.py
+++ b/lento/common/windows_block_controller.py
@@ -15,19 +15,22 @@ class WindowsBlockController(BlockController):
         card_to_use: str,
         lasts_for: int
     ):
-        launch = " ".join([
-            f"\"{str(Config.DAEMON_BINARY_PATH)}\"",
-            f"\"{card_to_use}\"",
-            str(lasts_for)
+        copycmd = " ".join([
+            "cp",
+            f"\"{bundled_binary_path}\"",
+            f"\"{Config.DAEMON_BINARY_PATH}\""
         ])
-        commands = [
-            f"powershell \"cp '{bundled_binary_path}' '{Config.DAEMON_BINARY_PATH}'\"",  # noqa: E501
-            f"powershell \"{launch}\""
+        daemon_launch_cmd = [
+            str(Config.DAEMON_BINARY_PATH),
+            str(card_to_use),
+            str(lasts_for)
         ]
-        result = []
-        for cmd in commands:
-            result.append(subprocess.call(cmd, shell=True))
-        return result
+        results = []
+        results.append(
+            subprocess.call(f"powershell \"{copycmd}\"", shell=True)
+        )
+        results.append(subprocess.Popen(daemon_launch_cmd, shell=False))
+        return results
 
     def daemon_takedown(self):
         cmd = f"powershell \"rm -Force '{Config.DAEMON_BINARY_PATH}'\""

--- a/lento/gui/card.py
+++ b/lento/gui/card.py
@@ -1,6 +1,5 @@
 from PySide6.QtGui import Qt
 from PySide6.QtWidgets import QFrame, QScrollArea, QVBoxLayout, QWidget  # noqa: E501
-from lento.common import get_block_controller
 from lento.gui.timer import TimerView
 from lento.gui.title import Title
 from lento.gui.websitelist import WebsiteList
@@ -12,17 +11,7 @@ class Card(QWidget):
         super().__init__()
 
         self.ACTIVATED_CARD = activated_card
-
-        if self.ACTIVATED_CARD is not None:
-            if self.ACTIVATED_CARD == DATA["name"]:
-                block_controller = get_block_controller()
-                self.TIME = block_controller.get_remaining_block_time()
-                if self.TIME == 0:
-                    block_controller.end_block()
-            else:
-                self.TIME = DATA["time"]
-        else:
-            self.TIME = DATA["time"]
+        self.TIME = DATA["time"]
 
         body_layout = QVBoxLayout()
 

--- a/lento/gui/timer.py
+++ b/lento/gui/timer.py
@@ -16,7 +16,7 @@ class TimerView(QWidget):
         self.CURRENT_CARD = current_card
         self.TIME_PRESET = time_preset
         self.refresh = refresh_handler
-        self.TIMER = QTimer(self, interval=1000, timeout=self.refresh)
+        self.TIMER = QTimer(self, interval=1000, timeout=self.reload_timer)
 
         self.BLOCK_IS_RUNNING = activated_card is not None
         if self.BLOCK_IS_RUNNING:
@@ -63,11 +63,11 @@ class TimerView(QWidget):
                     item.setEnabled(False)
             timer_boxes.addWidget(item)
 
-        start_button = QPushButton("Start Block")
-        start_button.clicked.connect(self.start_block)
+        self.start_button = QPushButton("Start Block")
+        self.start_button.clicked.connect(self.start_block)
 
         main_layout.addLayout(timer_boxes)
-        main_layout.addWidget(start_button)
+        main_layout.addWidget(self.start_button)
 
         self.setLayout(main_layout)
 
@@ -129,4 +129,25 @@ class TimerView(QWidget):
         print(f"START BLOCK WITH CARD {self.CURRENT_CARD} AND TOTAL {total}")
         block_controller = get_block_controller()
         block_controller.start_block(self.CURRENT_CARD, int(total))
+        self.BLOCK_IS_RUNNING = True
+        self.start_button.setEnabled(False)
+        self.TIMER.start()
+
+    def reload_timer(self):
+        block_controller = get_block_controller()
+        time = block_controller.get_remaining_block_time()
+        if time == 0:
+            block_controller.end_block()
+            return self.refresh()
+        self.TIME = self.split_seconds(time)
+        self.hour_box.setText(self.TIME["hour"])
+        self.mins_box1.setText(self.TIME["mins1"])
+        self.mins_box2.setText(self.TIME["mins2"])
+        self.secs_box1.setText(self.TIME["secs1"])
+        self.secs_box2.setText(self.TIME["secs2"])
+        for item in [
+            self.hour_box, self.mins_box1, self.mins_box2,
+            self.secs_box1, self.secs_box2
+        ]:
+            item.setEnabled(False)
         self.TIMER.start()

--- a/lento/gui/timer.py
+++ b/lento/gui/timer.py
@@ -135,7 +135,7 @@ class TimerView(QWidget):
 
     def reload_timer(self):
         block_controller = get_block_controller()
-        time = block_controller.get_remaining_block_time()
+        time = block_controller.get_remaining_block_time(self.TIME_PRESET)
         if time == 0:
             block_controller.end_block()
             return self.refresh()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1074,7 +1074,9 @@ FileName
         "/tmp/lentodaemon Untitled Card 42": "daemon launched",
         "\\tmp\\lentodaemon Untitled Card 42": "daemon launched",
         "powershell \"cp \"lentodaemon.exe\" \"/tmp/lentodaemon\"\"": "Windows daemon copied",
-        "powershell \"rm -Force \'/tmp/lentodaemon\'\"": "Windows block cleanup finished"
+        "powershell \"cp \"lentodaemon.exe\" \"\\tmp\\lentodaemon\"\"": "Windows daemon copied",
+        "powershell \"rm -Force \'/tmp/lentodaemon\'\"": "Windows block cleanup finished",
+        "powershell \"rm -Force \'\\tmp\\lentodaemon\'\"": "Windows block cleanup finished"
     }
     return cases[cmd]
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1029,6 +1029,8 @@ class fake_rgb:
         return True
 
 def fake_subprocess(cmd, shell=True):
+    if type(cmd) is list:
+        cmd = " ".join(cmd)
     correct_trello_path = "".join([
         str(os.path.join(
             Config.DRIVE_LETTER,
@@ -1068,12 +1070,8 @@ FileName
         "networksetup -setwebproxystate wi-fi off": "macOS web proxy deactivated",
         "networksetup -setsecurewebproxystate wi-fi off": "macOS secure web proxy deactivated",
         f"cp \"lentodaemon\" \"{Config.DAEMON_BINARY_PATH}\"": "macOS daemon copied",
-        " ".join([
-            f"\"{str(Config.DAEMON_BINARY_PATH)}\"",
-            f"\"Untitled Card\"",
-            str(42)
-        ]): "daemon launched",
-        f"rm -f \"{Config.DAEMON_BINARY_PATH}\"": "macOS block cleanup finished"
+        f"rm -f \"{Config.DAEMON_BINARY_PATH}\"": "macOS block cleanup finished",
+        "/tmp/lentodaemon Untitled Card 42": "daemon launched"
     }
     return cases[cmd]
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1071,7 +1071,8 @@ FileName
         "networksetup -setsecurewebproxystate wi-fi off": "macOS secure web proxy deactivated",
         f"cp \"lentodaemon\" \"{Config.DAEMON_BINARY_PATH}\"": "macOS daemon copied",
         f"rm -f \"{Config.DAEMON_BINARY_PATH}\"": "macOS block cleanup finished",
-        "/tmp/lentodaemon Untitled Card 42": "daemon launched"
+        "/tmp/lentodaemon Untitled Card 42": "daemon launched",
+        "\\tmp\\lentodaemon Untitled Card 42": "daemon launched"
     }
     return cases[cmd]
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1072,7 +1072,9 @@ FileName
         f"cp \"lentodaemon\" \"{Config.DAEMON_BINARY_PATH}\"": "macOS daemon copied",
         f"rm -f \"{Config.DAEMON_BINARY_PATH}\"": "macOS block cleanup finished",
         "/tmp/lentodaemon Untitled Card 42": "daemon launched",
-        "\\tmp\\lentodaemon Untitled Card 42": "daemon launched"
+        "\\tmp\\lentodaemon Untitled Card 42": "daemon launched",
+        "powershell \"cp \"lentodaemon.exe\" \"/tmp/lentodaemon\"\"": "Windows daemon copied",
+        "powershell \"rm -Force \'/tmp/lentodaemon\'\"": "Windows block cleanup finished"
     }
     return cases[cmd]
 

--- a/tests/test_macos_block_controller.py
+++ b/tests/test_macos_block_controller.py
@@ -12,6 +12,7 @@ def test_start_block_controller_works_properly(monkeypatch, tmp_path):
     monkeypatch.setattr(platform, "system", lambda: "Darwin")
     monkeypatch.setattr(utils, "get_data_file_path", lambda x: x)
     monkeypatch.setattr(subprocess, "call", helpers.fake_subprocess)
+    monkeypatch.setattr(subprocess, "Popen", helpers.fake_subprocess)
     monkeypatch.setattr(
         Config,
         "SETTINGS_PATH",

--- a/tests/test_windows_block_controller.py
+++ b/tests/test_windows_block_controller.py
@@ -1,0 +1,56 @@
+import json
+import platform
+import subprocess
+from pathlib import Path
+from lento import utils
+from lento.common import get_block_controller
+from lento.config import Config
+from tests import helpers
+
+
+def test_start_block_controller_works_properly(monkeypatch, tmp_path):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(utils, "get_data_file_path", lambda x: x)
+    monkeypatch.setattr(subprocess, "call", helpers.fake_subprocess)
+    monkeypatch.setattr(subprocess, "Popen", helpers.fake_subprocess)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    monkeypatch.setattr(
+        Config,
+        "DAEMON_BINARY_PATH",
+        Path("/tmp") / "lentodaemon"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["filled_config"]
+    ))
+    block_controller = get_block_controller()
+    result = block_controller.start_block("Untitled Card", 42)
+    assert result == [
+        "Windows daemon copied",
+        "daemon launched"
+    ]
+
+
+def test_end_block_controller_works_properly(monkeypatch, tmp_path):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(utils, "get_data_file_path", lambda x: x)
+    monkeypatch.setattr(subprocess, "call", helpers.fake_subprocess)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    monkeypatch.setattr(
+        Config,
+        "DAEMON_BINARY_PATH",
+        Path("/tmp") / "lentodaemon"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config_with_activated_card"]
+    ))
+    block_controller = get_block_controller()
+    result = block_controller.end_block()
+    assert result == "Windows block cleanup finished"


### PR DESCRIPTION
Prevents the GUI from freezing or completely re-rendering once the daemon launches and the timer starts. However, there's still a bug where the timer only updates every 11 seconds or so, which I have yet to resolve.