### PR TITLE
refactor: move CardsManagement to `pathlib`

### DIFF
--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -40,9 +40,7 @@ def delete_card(card_to_delete):
 
 
 def update_metadata(card_to_modify, field_to_modify, new_value):
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if settings["cards"][card_to_modify][field_to_modify] is None:
         raise Exception("Card field is nonexistent!")
@@ -59,8 +57,7 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
         }
         settings["cards"] = new_cards
 
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -87,9 +87,7 @@ def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
 
 def update_site_blocklists(card_to_modify, list_to_modify, new_sites_dict):
     """Update one of the blocked_sites lists. Minimal validation."""
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if settings["cards"][card_to_modify][list_to_modify] is None:
         raise Exception("List is nonexistent!")
@@ -102,15 +100,11 @@ def update_site_blocklists(card_to_modify, list_to_modify, new_sites_dict):
         raise Exception("new_sites_dict is not a dict!")
 
     settings["cards"][card_to_modify][list_to_modify] = new_sites_dict
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
-
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
     card = settings["cards"][card_to_modify]
 
     current_os = platform.system()
@@ -187,14 +181,11 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
     else:
         raise Exception("OS name invalid or not found!")
 
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def update_app_blocklists(card_to_modify, list_to_modify, new_list_structure):
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if list_to_modify not in [
                 "hard_blocked_apps",
@@ -204,8 +195,7 @@ def update_app_blocklists(card_to_modify, list_to_modify, new_list_structure):
 
     settings["cards"][card_to_modify][list_to_modify] = new_list_structure
 
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def add_notification(
@@ -220,9 +210,7 @@ def add_notification(
             body,
             audio_paths
         ):
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if not isinstance(name, str):
         raise Exception("Name must be a string!")
@@ -268,15 +256,12 @@ def add_notification(
     card = settings["cards"][card_to_modify]
     card["notifications"][str(uuid.uuid4().hex)] = new_notif
 
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def update_notification_list(card_to_modify, new_notifs_dict):
     """Update notifications for a card. Minimal validation."""
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if not isinstance(new_notifs_dict, dict):
         raise Exception("new_notifs_dict is not a dict!")
@@ -296,32 +281,23 @@ def update_notification_list(card_to_modify, new_notifs_dict):
             raise Exception(f"Notif {item} had invalid structure!")
 
     settings["cards"][card_to_modify]["notifications"] = new_notifs_dict
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def add_goal(card_to_modify: str, goal_to_add: str) -> None:
     """Add a goal to a card. Automatically adds as disabled."""
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if not isinstance(goal_to_add, str):
         raise Exception("Goal to add is not string!")
 
     settings["cards"][card_to_modify]["goals"][goal_to_add] = False
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def update_goal_list(card_to_modify, new_goals_dict):
     """Update goals for a card. Minimal validation."""
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        settings = json.load(settings_json)
+    settings = json.loads(Config.SETTINGS_PATH.read_text())
 
     if not isinstance(new_goals_dict, dict):
         raise Exception("new_goals_dict is not a dict!")
@@ -330,9 +306,7 @@ def update_goal_list(card_to_modify, new_goals_dict):
             raise Exception(f"Goal '{item}' has invalid structure!")
 
     settings["cards"][card_to_modify]["goals"] = new_goals_dict
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(settings, settings_json)
+    Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
 def activate_block_in_settings(card_to_activate: str):

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -136,8 +136,7 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
                 )
             else:
                 plist_path = Path(app, "Contents", "Info.plist")
-            with open(plist_path, "rb") as fp:
-                app_plist = plistlib.load(fp)
+            app_plist = plistlib.loads(plist_path.read_bytes())
             icon_name = app_plist["CFBundleIconFile"]
             if icon_name[-5:] != ".icns":
                 icon_name = app_plist["CFBundleIconFile"] + ".icns"
@@ -149,7 +148,6 @@ def add_to_app_blocklists(card_to_modify, list_to_modify, apps_to_add):
             )
             im = Image.open(original_icon_path)
             rgb_im = im.convert("RGB")
-
             path_to_save_at = str(Config.APPDATA_PATH / (app_name + ".jpg"))
             rgb_im.save(path_to_save_at)
 

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -82,50 +82,57 @@ def test_delete_card_denies_incorrect_card_name(monkeypatch, tmp_path):
 
 
 def test_update_metadata_changes_nonname_data_correctly(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     CardsManagement.update_metadata("Untitled Card", "time", 42)
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        new_settings = json.load(settings_json)
+    result = json.loads(Config.SETTINGS_PATH.read_text())
 
     expected_result = copy.deepcopy(helpers.data["bare_config"])
     expected_result["cards"]["Untitled Card"]["time"] = 42
-    assert expected_result == new_settings
+    assert expected_result == result
 
 
 def test_update_metadata_changes_name_data_correctly(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     CardsManagement.update_metadata(
         "Untitled Card",
         "name",
         "World Domination"
     )
-    with open(path, "r", encoding="UTF-8") as settings_json:
-        new_settings = json.load(settings_json)
+    result = json.loads(Config.SETTINGS_PATH.read_text())
 
     expected_result = helpers.data["updated_bare_config"]
-    assert "World Domination" in new_settings["cards"]
-    assert expected_result == new_settings
+    assert "World Domination" in result["cards"]
+    assert expected_result == result
 
 
 def test_update_metdata_denies_incorrect_card_name_or_field(
             monkeypatch,
             tmp_path
         ):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(KeyError):
         CardsManagement.update_metadata(
@@ -158,11 +165,14 @@ def test_update_metadata_denies_restricted_field_change(monkeypatch, tmp_path):
 
 
 def test_update_metadata_validates_time_as_number(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(ValueError):
         CardsManagement.update_metadata(

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import os
 from pathlib import Path
 import platform
 import pytest
@@ -382,39 +381,42 @@ def test_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
         "SETTINGS_PATH",
         Path(tmp_path) / "lentosettings.json"
     )
+    monkeypatch.setattr(
+        Config,
+        "APPDATA_PATH",
+        Path(tmp_path, "Library", "Application Support", "Lento")
+    )
     folders = {
-        "application_support": os.path.join(
+        "application_support": Path(
             "Library",
             "Application Support",
             "Lento"
         ),
         "apps_folder": "Applications",
-        "gris_folders": os.path.join("Applications", "GRIS.app", "Contents"),
-        "scrivener_folder": os.path.join(
+        "gris_folders": Path("Applications", "GRIS.app", "Contents"),
+        "scrivener_folder": Path(
             "Applications",
             "Scrivener.app",
             "Contents"
         ),
-        "nnw_folder": os.path.join(
+        "nnw_folder": Path(
             "Applications",
             "NetNewsWire.app",
             "Contents"
         )
     }
     for f in folders.keys():
-        os.makedirs(Path(tmp_path, folders[f]))
+        Path(tmp_path, folders[f]).mkdir(parents=True, exist_ok=True)
 
     for file in ["GRIS", "Scrivener", "NetNewsWire"]:
-        path = os.path.join(
+        plist_file = Path(
             tmp_path,
             "Applications",
             file + ".app",
             "Contents",
             "Info.plist"
         )
-        plist_file = open(path, "w", encoding="UTF-8")
-        plist_file.write(helpers.data[file])
-        plist_file.close()
+        plist_file.write_text(helpers.data[file])
 
     monkeypatch.setattr(
         Config,
@@ -447,26 +449,26 @@ def test_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     assert hb_list["GRIS"] == {
         "enabled": True,
         "bundle_id": "unity.nomada studio.GRIS",
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/GRIS.jpg"
-        )
+        "app_icon_path": str(Path(
+            Config.APPDATA_PATH,
+            "GRIS.jpg"
+        ))
     }
     assert hb_list["Scrivener"] == {
         "enabled": True,
         "bundle_id": "com.literatureandlatte.scrivener3",
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/Scrivener.jpg"
-        )
+        "app_icon_path": str(Path(
+            Config.APPDATA_PATH,
+            "Scrivener.jpg"
+        ))
     }
     assert hb_list["NetNewsWire"] == {
         "enabled": True,
         "bundle_id": "com.ranchero.NetNewsWire-Evergreen",
-        "app_icon_path": os.path.join(
-            os.path.expanduser("~"),
-            "Library/Application Support/Lento/NetNewsWire.jpg"
-        )
+        "app_icon_path": str(Path(
+            Config.APPDATA_PATH,
+            "NetNewsWire.jpg"
+        ))
     }
     assert list(hb_list.keys()) == ["GRIS", "Scrivener", "NetNewsWire"]
 
@@ -524,21 +526,21 @@ def test_add_to_app_blocklists_rejects_dupes_darwin(monkeypatch, tmp_path):
 
 def test_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     appdata_dict = copy.deepcopy(helpers.data["proper_apps_dict"])
-    appdata_dict["vivaldi"]["path"] = os.path.join(
-        os.path.expanduser("~"),
+    appdata_dict["vivaldi"]["path"] = str(Path(
+        tmp_path,
         "AppData",
         "Local",
         "Vivaldi",
         "Application",
         "vivaldi.exe"
-    )
-    appdata_dict["vivaldi"]["icon_path"] = os.path.join(
-        os.path.expanduser("~"),
+    ))
+    appdata_dict["vivaldi"]["icon_path"] = str(Path(
+        tmp_path,
         "AppData",
         "Local",
         "Lento",
         "vivaldi.bmp"
-    )
+    ))
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     monkeypatch.setattr(
         Config,
@@ -550,21 +552,21 @@ def test_add_to_app_blocklists_adds_data_windows(monkeypatch, tmp_path):
     ))
 
     apps_to_add = copy.deepcopy(helpers.data["apps_to_add"])
-    apps_to_add[1]["path"] = os.path.join(
-        os.path.expanduser("~"),
+    apps_to_add[1]["path"] = str(Path(
+        tmp_path,
         "AppData",
         "Local",
         "Vivaldi",
         "Application",
         "vivaldi.exe"
-    )
-    apps_to_add[1]["icon_path"] = os.path.join(
-        os.path.expanduser("~"),
+    ))
+    apps_to_add[1]["icon_path"] = str(Path(
+        tmp_path,
         "AppData",
         "Local",
         "Lento",
         "vivaldi.bmp"
-    )
+    ))
 
     CardsManagement.add_to_app_blocklists(
         "Untitled Card",

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -419,7 +419,7 @@ def test_add_to_app_blocklists_adds_data_darwin(monkeypatch, tmp_path):
     monkeypatch.setattr(
         Config,
         "MACOS_APPLICATION_FOLDER",
-        os.path.join(tmp_path, folders["apps_folder"])
+        Path(tmp_path, folders["apps_folder"])
     )
     monkeypatch.setattr(Image, "open", lambda x: helpers.fake_image)
     monkeypatch.setattr(platform, "system", lambda: "Darwin")

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -77,7 +77,7 @@ def test_delete_card_denies_incorrect_card_name(monkeypatch, tmp_path):
         helpers.data["bare_config"]
     ))
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Llama Taming"):
         CardsManagement.delete_card("Llama Taming")
 
 
@@ -134,14 +134,14 @@ def test_update_metdata_denies_incorrect_card_name_or_field(
         helpers.data["bare_config"]
     ))
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Llama Training"):
         CardsManagement.update_metadata(
             "Llama Training",
             "name",
             "World Domination"
         )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="llamas_collected"):
         CardsManagement.update_metadata(
             "Untitled Card",
             "llamas_collected",
@@ -150,13 +150,16 @@ def test_update_metdata_denies_incorrect_card_name_or_field(
 
 
 def test_update_metadata_denies_restricted_field_change(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
-
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Card field is restricted!"):
         CardsManagement.update_metadata(
             "Untitled Card",
             "id",
@@ -174,11 +177,14 @@ def test_update_metadata_validates_time_as_number(monkeypatch, tmp_path):
         helpers.data["bare_config"]
     ))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="could not convert string to float: 'Eternal Reign of the Llama'"
+    ):
         CardsManagement.update_metadata(
             "Untitled Card",
             "time",
-            "Eternal Reign of the Llama Lords"
+            "Eternal Reign of the Llama"
         )
 
 
@@ -261,14 +267,14 @@ def test_add_to_site_blocklists_denies_incorrect_card_or_list_name(
         helpers.data["bare_config"]
     ))
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="hard_blocked_NIGHTS"):
         CardsManagement.add_to_site_blocklists(
             "Untitled Card",
             "hard_blocked_NIGHTS",
             "https://youtube.com"
         )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Llama Taming"):
         CardsManagement.add_to_site_blocklists(
             "Llama Taming",
             "hard_blocked_sites",
@@ -346,7 +352,7 @@ def test_update_site_blocklists_rejects_flawed_data(monkeypatch, tmp_path):
             settings_json
         )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="hard_blocked_NIGHTS"):
         CardsManagement.update_site_blocklists(
             "Untitled Card",
             "hard_blocked_NIGHTS",
@@ -658,7 +664,7 @@ def test_update_app_blocklists_rejects_incorrect(monkeypatch, tmp_path):
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config"], settings_json)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Llama"):
         CardsManagement.update_app_blocklists(
             "Llama",
             "hard_blocked_apps",
@@ -766,7 +772,7 @@ def test_add_notification_rejects_incorrect_data(monkeypatch, tmp_path):
                 "Frog": "/System/Library/Sounds/Frog.aiff"
             }
         )
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Llama"):
         CardsManagement.add_notification(
             "Test Notif 1",
             True,
@@ -1084,7 +1090,7 @@ def test_add_goal_rejects_flawed_data(monkeypatch, tmp_path):
             "Untitled Card",
             42
         )
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="42"):
         CardsManagement.add_goal(
             42,
             "Conquer world"
@@ -1144,12 +1150,12 @@ def test_update_goal_list_rejects_flawed_data(monkeypatch, tmp_path):
     with open(path, "w", encoding="UTF-8") as settings_json:
         json.dump(helpers.data["bare_config_with_goals"], settings_json)
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="new_goals_dict is not a dict!"):
         CardsManagement.update_goal_list(
             "Untitled Card",
             "Llama"
         )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Llama"):
         CardsManagement.update_goal_list(
             "Llama",
             helpers.data["reordered_goal_dict"]

--- a/tests/test_cards_management.py
+++ b/tests/test_cards_management.py
@@ -661,11 +661,14 @@ def test_update_app_blocklists_works_correctly(monkeypatch, tmp_path):
 
 
 def test_update_app_blocklists_rejects_incorrect(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(KeyError, match="Llama"):
         CardsManagement.update_app_blocklists(
@@ -1044,11 +1047,14 @@ def test_update_notification_list_deletes_correctly(monkeypatch, tmp_path):
 
 
 def test_update_notification_list_rejects_flawed_data(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config_multiple_notif"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(Exception, match="new_notifs_dict is not a dict!"):
         CardsManagement.update_notification_list(
@@ -1087,11 +1093,14 @@ def test_add_goal_works_correctly(monkeypatch, tmp_path):
 
 
 def test_add_goal_rejects_flawed_data(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(Exception, match="Goal to add is not string!"):
         CardsManagement.add_goal(
@@ -1152,11 +1161,14 @@ def test_update_goal_list_deletes_correctly(monkeypatch, tmp_path):
 
 
 def test_update_goal_list_rejects_flawed_data(monkeypatch, tmp_path):
-    monkeypatch.setattr(os.path, "expanduser", lambda x: tmp_path)
-    path = os.path.join(os.path.expanduser("~"), "lentosettings.json")
-
-    with open(path, "w", encoding="UTF-8") as settings_json:
-        json.dump(helpers.data["bare_config_with_goals"], settings_json)
+    monkeypatch.setattr(
+        Config,
+        "SETTINGS_PATH",
+        Path(tmp_path) / "lentosettings.json"
+    )
+    Config.SETTINGS_PATH.write_text(json.dumps(
+        helpers.data["bare_config"]
+    ))
 
     with pytest.raises(Exception, match="new_goals_dict is not a dict!"):
         CardsManagement.update_goal_list(


### PR DESCRIPTION
**Added the following:**
- Significant updates to `CardsManagement` and the corresponding tests to move from `os`, `open()` and more to `pathlib`.

**Things of note:**
- This may or may not fix other errors about finding/opening the settings file from other parts of the codebase, as we are now using the `Config` object as much as possible

**Dependencies changed:**
- None

**Non-ideal but non-dealbreakers:**
- I still haven't refactored this into an actual class yet, because I have some ideas for possibly splitting this up into different classes for each list and having `CardsManagement` as its own module.
    - This could be time-consuming and breaks the API so I'll probably leave this until after v1.0.0 or so.