### PR TITLE
feat(daemon): add notification functionality

### DIFF
--- a/daemon/daemonprompt.py
+++ b/daemon/daemonprompt.py
@@ -27,11 +27,14 @@ class DaemonPrompt():
                 return False
 
     def windows_softblock_prompt(self, title, message):
+        MB_YESNO = 0x04
+        MB_ICONWARNING = 0x30
+        MB_SYSTEMMODAL = 0x1000
         choice = ctypes.windll.user32.MessageBoxW(
             0,
             message,
             title,
-            36
+            MB_YESNO | MB_ICONWARNING | MB_SYSTEMMODAL
         )
         # the MessageBox foreign function returns 6 for OK, 7 for No.
         if choice == 6:
@@ -54,9 +57,11 @@ class DaemonPrompt():
         ])
 
     def windows_notif_prompt(self, title, message):
-        return ctypes.windll.user32.MessageBoxW(
+        MB_SYSTEMMODAL = 0x1000
+        MB_OK = 0x00
+        ctypes.windll.user32.MessageBoxW(
             0,
             message,
             title,
-            0
+            MB_SYSTEMMODAL | MB_OK
         )

--- a/daemon/daemonprompt.py
+++ b/daemon/daemonprompt.py
@@ -10,17 +10,16 @@ class DaemonPrompt():
     def display_prompt(self, title, message):
         match platform.system():
             case "Darwin":
-                return self.macos_softblock_prompt(" ".join([title, message]))
+                return self.macos_softblock_prompt(title, message)
             case "Windows":
                 return self.windows_softblock_prompt(title, message)
 
-    def macos_softblock_prompt(self, message):
-        choice = subprocess.check_output(" ".join([
+    def macos_softblock_prompt(self, title, message):
+        choice = subprocess.check_output([
             "osascript",
             "-e",
-            f"'display dialog \"{message}\"",  # noqa: E501
-            "buttons {\"No\", \"Yes\"}'"
-        ]), shell=True)
+            f"""display dialog "{message}" with title "{title}" buttons {"No", "Yes"}"""  # noqa: E501
+        ])
         match choice.decode("utf-8").strip():
             case "button returned:Yes":
                 return True
@@ -39,3 +38,25 @@ class DaemonPrompt():
             return True
         else:
             return False
+
+    def show_notif_popup(self, title, message):
+        match platform.system():
+            case "Darwin":
+                return self.macos_notif_prompt(title, message)
+            case "Windows":
+                return self.windows_notif_prompt(title, message)
+
+    def macos_notif_prompt(self, title, message):
+        return subprocess.Popen([
+            "osascript",
+            "-e",
+            f"""display dialog "{message}" with title "{title}" buttons "OK" default button 1"""  # noqa: E501
+        ])
+
+    def windows_notif_prompt(self, title, message):
+        return ctypes.windll.user32.MessageBoxW(
+            0,
+            message,
+            title,
+            0
+        )

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -3,6 +3,7 @@ import playsound
 import subprocess
 from pathlib import Path
 from plyer import notification
+from daemon.daemonprompt import DaemonPrompt
 
 
 class LentoNotif():
@@ -46,3 +47,7 @@ class LentoNotif():
             case "Windows":
                 for item in self.audio_paths.keys():
                     playsound.playsound(Path(self.audio_paths[item]))
+
+    def show_notif_popup(self):
+        prompt = DaemonPrompt()
+        return prompt.show_notif_popup(self.title, self.body)

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -1,6 +1,6 @@
 import platform
 import subprocess
-from win10toast import ToastNotifier
+from plyer import notification
 
 
 class LentoNotif():
@@ -28,9 +28,9 @@ class LentoNotif():
         print(
             f"==\nWIN NOTIF WITH TITLE {self.title} AND BODY {self.body}\n=="
         )
-        toaster = ToastNotifier()
-        toaster.show_toast(
-            self.title,
-            self.body,
-            duration=10
+        notification.notify(
+            title=self.title,
+            message=self.body,
+            app_name="Lento",
+            timeout=10
         )

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -1,5 +1,6 @@
 import platform
 import subprocess
+from win10toast import ToastNotifier
 
 
 class LentoNotif():
@@ -17,9 +18,6 @@ class LentoNotif():
                 return self.windows_notif()
 
     def macos_notif(self):
-        print(
-            f"==\nMACOS NOTIF WITH TITLE {self.title} AND BODY {self.body}\n=="
-        )
         subprocess.Popen([
             "osascript",
             "-e",
@@ -29,4 +27,10 @@ class LentoNotif():
     def windows_notif(self):
         print(
             f"==\nWIN NOTIF WITH TITLE {self.title} AND BODY {self.body}\n=="
+        )
+        toaster = ToastNotifier()
+        toaster.show_toast(
+            self.title,
+            self.body,
+            duration=10
         )

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -3,7 +3,7 @@ import subprocess
 from daemon.daemonprompt import DaemonPrompt
 from pathlib import Path
 from plyer import notification
-from pygame import mixer
+from pygame import mixer, error as PygameError
 
 
 class LentoNotif():
@@ -49,7 +49,13 @@ class LentoNotif():
                     ])
             case "Windows":
                 for item in self.audio_paths.keys():
-                    mixer.init()
+                    try:
+                        mixer.init()
+                    except PygameError as e:
+                        if str(e) == "ALSA: Couldn't open audio device: No such file or directory":  # noqa: E501
+                            pass
+                        else:
+                            raise PygameError(e)
                     mixer.music.load(str(Path(self.audio_paths[item])))
                     mixer.music.play()
 

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -1,6 +1,9 @@
 import platform
-import playsound
 import subprocess
+try:
+    import winsound
+except ImportError:
+    pass
 from pathlib import Path
 from plyer import notification
 from daemon.daemonprompt import DaemonPrompt
@@ -43,10 +46,16 @@ class LentoNotif():
         match platform.system():
             case "Darwin":
                 for item in self.audio_paths.keys():
-                    subprocess.call(["afplay", Path(self.audio_paths[item])])
+                    subprocess.Popen([
+                        "afplay",
+                        str(Path(self.audio_paths[item]))
+                    ])
             case "Windows":
                 for item in self.audio_paths.keys():
-                    playsound.playsound(Path(self.audio_paths[item]))
+                    winsound.PlaySound(
+                        str(Path(self.audio_paths[item])),
+                        winsound.SND_ASYNC
+                    )
 
     def show_notif_popup(self):
         prompt = DaemonPrompt()

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -1,12 +1,9 @@
 import platform
 import subprocess
-try:
-    import winsound
-except ImportError:
-    pass
+from daemon.daemonprompt import DaemonPrompt
 from pathlib import Path
 from plyer import notification
-from daemon.daemonprompt import DaemonPrompt
+from pygame import mixer
 
 
 class LentoNotif():
@@ -52,10 +49,9 @@ class LentoNotif():
                     ])
             case "Windows":
                 for item in self.audio_paths.keys():
-                    winsound.PlaySound(
-                        str(Path(self.audio_paths[item])),
-                        winsound.SND_ASYNC
-                    )
+                    mixer.init()
+                    mixer.music.load(str(Path(self.audio_paths[item])))
+                    mixer.music.play()
 
     def show_notif_popup(self):
         prompt = DaemonPrompt()

--- a/daemon/lento_notif.py
+++ b/daemon/lento_notif.py
@@ -1,5 +1,7 @@
 import platform
+import playsound
 import subprocess
+from pathlib import Path
 from plyer import notification
 
 
@@ -9,8 +11,9 @@ class LentoNotif():
         self.name = notif["name"]
         self.title = notif["title"]
         self.body = notif["body"]
+        self.audio_paths = notif["audio_paths"]
 
-    def send(self):
+    def send_banner(self):
         match platform.system():
             case "Darwin":
                 return self.macos_notif()
@@ -34,3 +37,12 @@ class LentoNotif():
             app_name="Lento",
             timeout=10
         )
+
+    def play_audio(self):
+        match platform.system():
+            case "Darwin":
+                for item in self.audio_paths.keys():
+                    subprocess.call(["afplay", Path(self.audio_paths[item])])
+            case "Windows":
+                for item in self.audio_paths.keys():
+                    playsound.playsound(Path(self.audio_paths[item]))

--- a/daemon/notifications_controller.py
+++ b/daemon/notifications_controller.py
@@ -70,7 +70,7 @@ class NotifsController:
             for item in data[trigger]:
                 notif_record = Record.get(Record.key == item)
                 triggered_notifs[item] = pickle.loads(notif_record.data)
-        except KeyError:
+        except (KeyError, TypeError):
             pass
         db.close()
         return triggered_notifs

--- a/daemon/notifications_controller.py
+++ b/daemon/notifications_controller.py
@@ -116,7 +116,9 @@ class NotifsController:
             current_notif = notifs_to_fire[item]
             match current_notif["type"]:
                 case "banner":
-                    LentoNotif(current_notif).send()
+                    LentoNotif(current_notif).send_banner()
+                case "audio":
+                    LentoNotif(current_notif).play_audio()
                 case _:
                     notif = notifs_to_fire[item]
                     name = notif["name"]
@@ -128,7 +130,7 @@ class NotifsController:
                         f"TITLE {title} WITH BODY {body} OF TYPE {notif_type}"
                     )
                     print(f"===END NOTIFICATION: {name}===")
-                    self.update_fire_date(item)
+            self.update_fire_date(item)
 
     def clear_notifs(self):
         Record.delete().where(Record.key is not None).execute()

--- a/daemon/notifications_controller.py
+++ b/daemon/notifications_controller.py
@@ -119,6 +119,8 @@ class NotifsController:
                     LentoNotif(current_notif).send_banner()
                 case "audio":
                     LentoNotif(current_notif).play_audio()
+                case "popup":
+                    LentoNotif(current_notif).show_notif_popup()
                 case _:
                     notif = notifs_to_fire[item]
                     name = notif["name"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
 plyer>=2.0.0
+pygame>=2.1.2
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
 plyer>=2.0.0
+playsound>=1.3.0
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dotenv>=0.20.0
 pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
-win10toast>=0.9
+# win10toast>=0.9
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dotenv>=0.20.0
 pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
+win10toast>=0.9
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
 plyer>=2.0.0
-playsound>=1.3.0
 
 # Dev
 flake8>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dotenv>=0.20.0
 pillow>=9.1.0
 proxy.py>=2.4.1
 peewee>=3.14.10
-# win10toast>=0.9
+plyer>=2.0.0
 
 # Dev
 flake8>=4.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,0 @@
-import platform
-
-collect_ignore = []
-if platform.system() != "Windows":
-    collect_ignore.append("test_windows_proxy_controller.py")

--- a/tests/test_lento_notif.py
+++ b/tests/test_lento_notif.py
@@ -1,0 +1,129 @@
+import platform
+import pytest
+import subprocess
+try:
+    import winsound
+except ImportError:
+    pass
+from daemon import lento_notif
+from daemon.lento_notif import LentoNotif
+from unittest.mock import MagicMock
+
+
+def test_init_notif_works_properly():
+    notif = LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": "LlamaAudio"
+    })
+    assert notif.name == "LlamaName"
+    assert notif.title == "LlamaTitle"
+    assert notif.body == "LlamaBody"
+    assert notif.audio_paths == "LlamaAudio"
+
+
+def test_send_banner_works_properly_darwin(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    mock_subprocess = MagicMock()
+    monkeypatch.setattr(subprocess, "Popen", mock_subprocess)
+    LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": None
+    }).send_banner()
+    mock_subprocess.assert_called_once_with([
+        "osascript",
+        "-e",
+        """display notification "LlamaBody" with title "LlamaTitle\""""  # noqa: E501
+    ])
+
+
+def test_send_banner_works_properly_windows(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    mock_notification = MagicMock()
+    monkeypatch.setattr(lento_notif.notification, "notify", mock_notification)
+    LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": None
+    }).send_banner()
+    mock_notification.assert_called_once_with(
+        title="LlamaTitle",
+        message="LlamaBody",
+        app_name="Lento",
+        timeout=10
+    )
+
+
+def test_play_audio_works_properly_darwin(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    mock_subprocess = MagicMock()
+    monkeypatch.setattr(subprocess, "Popen", mock_subprocess)
+    LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": {
+            "llama_theme": "/Users/LlamaLords/llama_theme.mp3",
+            "Daydream": "/Users/marika_takeuchi/daydream.mp3"
+        }
+    }).play_audio()
+    mock_subprocess.assert_any_call([
+        "afplay",
+        "/Users/LlamaLords/llama_theme.mp3"
+    ])
+    mock_subprocess.assert_any_call([
+        "afplay",
+        "/Users/marika_takeuchi/daydream.mp3"
+    ])
+    assert mock_subprocess.call_count == 2
+
+
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="`winsound` cannot be tested on non-Windows platforms"
+)
+def test_play_audio_works_properly_windows(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    mock_winsound = MagicMock()
+    monkeypatch.setattr(lento_notif.winsound, "PlaySound", mock_winsound)
+    LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": {
+            "llama_theme": "/Users/LlamaLords/llama_theme.mp3",
+            "Daydream": "/Users/marika_takeuchi/daydream.mp3"
+        }
+    }).play_audio()
+    mock_winsound.assert_any_call([
+        "/Users/LlamaLords/llama_theme.mp3",
+        winsound.SND_ASYNC
+    ])
+    mock_winsound.assert_any_call([
+        "/Users/marika_takeuchi/daydream.mp3",
+        winsound.SND_ASYNC
+    ])
+    assert mock_winsound.call_count == 2
+
+
+def test_show_popup_works_properly(monkeypatch):
+    mock_popup = MagicMock()
+    monkeypatch.setattr(
+        lento_notif.DaemonPrompt,
+        "show_notif_popup",
+        mock_popup
+    )
+    LentoNotif({
+        "name": "LlamaName",
+        "title": "LlamaTitle",
+        "body": "LlamaBody",
+        "audio_paths": None
+    }).show_notif_popup()
+    mock_popup.assert_called_once_with(
+        "LlamaTitle",
+        "LlamaBody"
+    )

--- a/tests/test_windows_proxy_controller.py
+++ b/tests/test_windows_proxy_controller.py
@@ -1,10 +1,18 @@
-from tests import helpers
-import proxy
 import platform
-import winreg
+import proxy
+import pytest
+try:
+    import winreg
+except ImportError:
+    pass
 from daemon import get_proxy
+from tests import helpers
 
 
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="`winreg` cannot be tested on non-Windows platforms"
+)
 def test_enable_system_proxy_windows(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     monkeypatch.setattr(winreg, "SetValueEx", helpers.fake_SetValueEx_enable)
@@ -14,6 +22,10 @@ def test_enable_system_proxy_windows(monkeypatch):
     assert result == ["proxyserver_command_run", "proxyenable_command_run"]
 
 
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="`winreg` cannot be tested on non-Windows platforms"
+)
 def test_disable_system_proxy_windows(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     monkeypatch.setattr(winreg, "SetValueEx", helpers.fake_SetValueEx_disable)


### PR DESCRIPTION
**Added the following:**
- Notifications based on time interval or blocked visit triggers.
- Users can set audio, banner, or popup notifications, which are processed accordingly.
- Better alerts for when platform-specific tests are skipped.

**Things of note:**
- I'm using `plyer` on Windows only even though it's technically cross-platform because I couldn't get it working on macOS for whatever reason.
- I'm using `subprocess` to call `afplay` for audio playback on macOS, but `pygame` on Windows, even though `pygame` is cross-platform. This is because `afplay` supports more file formats, such as `.m4a`, and is generally more lightweight.

**Dependencies changed:**
- Added `plyer>=2.0.0` - added for banner notifications on Windows.
- Added `pygame>=2.1.2` - added for audio playback on Windows, it's a bit heavier than I would like but it gets the job done. May replace later if I write a custom audio library.

**Non-ideal but non-dealbreakers:**
- Some things don't have tests, such as the `NotifsController` class, but I've added tests for things that are easy (like the `LentoNotif` class) and will go back and add the missing ones later.
- Since I'm using `afplay` on macOS and `pygame` on Windows, the async audio playback works slightly differently: on macOS, multiple audio clips will play over each other if the time interval trigger is shorter than the length of the clip, whereas on Windows clips will be cut off when the next one starts play. So there's a small difference in behaviour between platforms but I'm willing to let it go, for now. Might fix this in v1.1.0 or so.