### PR TITLE
feat: store favicons for blocked sites

### DIFF
--- a/docs/example-settings.json
+++ b/docs/example-settings.json
@@ -7,11 +7,20 @@
             "emoji": "💻",
             "time": 5400,
             "hard_blocked_sites": {
-                "twitter.com":  false,
-                "talk.macpowerusers.com": true
+                "twitter.com": {
+                    "enabled": false,
+                    "icon_path": "~/Library/Application Support/Lento/twitter.com.png"
+                },
+                "talk.macpowerusers.com": {
+                    "enabled": true,
+                    "icon_path": "~/Library/Application Support/Lento/talk.macpowerusers.com.png"
+                }
             },
             "soft_blocked_sites": {
-                "youtube.com": true
+                "youtube.com": {
+                    "enabled": true,
+                    "icon_path": "~/Library/Application Support/Lento/youtube.com.png"
+                }
             },
             "hard_blocked_apps": {
                 "GRIS": {

--- a/lento/common/cards_management.py
+++ b/lento/common/cards_management.py
@@ -3,6 +3,7 @@ import platform
 import plistlib
 import subprocess
 import uuid
+from grabicon import FaviconGrabber
 from lento.config import Config
 from lento.utils import is_url
 from pathlib import Path
@@ -60,6 +61,16 @@ def update_metadata(card_to_modify, field_to_modify, new_value):
     Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 
+def get_favicon(url):
+    grabber = FaviconGrabber()
+    favicons = grabber.grab(url)
+    icon = favicons[0]
+    trimmed_url = url.replace("\\", "_").replace("/", "_")
+    saved_icon_path = Config.APPDATA_PATH / f"{trimmed_url}.{icon.extension}"
+    saved_icon_path.write_bytes(icon.data)
+    return saved_icon_path
+
+
 def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
     """Add to either the `hard_blocked_sites` or `soft_blocked_sites` lists."""
     settings = json.loads(Config.SETTINGS_PATH.read_text())
@@ -81,7 +92,10 @@ def add_to_site_blocklists(card_to_modify, list_to_modify, new_value):
         if new_value in card_to_mod["hard_blocked_sites"]:
             raise Exception(f"'{new_value}' already hard blocked!")
 
-    settings["cards"][card_to_modify][list_to_modify][new_value] = True
+    settings["cards"][card_to_modify][list_to_modify][new_value] = {
+        "enabled": True,
+        "icon_path": str(get_favicon(new_value))
+    }
     Config.SETTINGS_PATH.write_text(json.dumps(settings))
 
 

--- a/lento/gui/applist.py
+++ b/lento/gui/applist.py
@@ -33,7 +33,7 @@ class AppList(QWidget):
             new_button = QPushButton(item)
 
             new_button.setCheckable(True)
-            # new_button.setChecked(self.INPUT_LIST[item])
+            new_button.setChecked(self.INPUT_LIST[item]["enabled"])
             new_button.clicked.connect(self.toggle_site)
 
             inner_list_layout.addWidget(new_button)
@@ -67,8 +67,8 @@ class AppList(QWidget):
 
     def toggle_site(self, checked):
         item = self.sender().text()
-        self.INPUT_LIST[item] = checked
-        CardsManagement.update_site_blocklists(
+        self.INPUT_LIST[item]["enabled"] = checked
+        CardsManagement.update_app_blocklists(
             self.CURRENT_CARD,
             self.CURRENT_LIST_KEY,
             self.INPUT_LIST

--- a/lento/gui/websitelist.py
+++ b/lento/gui/websitelist.py
@@ -32,7 +32,7 @@ class WebsiteList(QWidget):
             new_button = QPushButton(item)
 
             new_button.setCheckable(True)
-            new_button.setChecked(self.INPUT_LIST[item])
+            new_button.setChecked(self.INPUT_LIST[item]["enabled"])
             new_button.clicked.connect(self.toggle_site)
 
             inner_list_layout.addWidget(new_button)
@@ -65,7 +65,7 @@ class WebsiteList(QWidget):
 
     def toggle_site(self, checked):
         item = self.sender().text()
-        self.INPUT_LIST[item] = checked
+        self.INPUT_LIST[item]["enabled"] = checked
         CardsManagement.update_site_blocklists(
             self.CURRENT_CARD,
             self.CURRENT_LIST_KEY,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ proxy.py>=2.4.1
 peewee>=3.14.10
 plyer>=2.0.0
 pygame>=2.1.2
+grabicon>=0.1.2
 
 # Dev
 flake8>=4.0.1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1124,3 +1124,13 @@ class FakeSQLite:
 
     def close(self):
         return
+
+
+class fakeFavicon:
+    def grab(self, url):
+        return [FakeIcon(url)]
+
+class FakeIcon:
+    def __init__(self, url):
+        self.data = f"{url}.bytes"
+        self.extension = "png"


### PR DESCRIPTION
**Added the following:**
- Update `add_to_site_blocklists` to use a dict structure for each blocked sites.
- Add a `get_favicon` function to grab favicon data for a given URL.
- Add/update tests for the above.
- Update GUI lists to properly display and udpate the new dict structure.


**Things of note:**
- **This PR requires a settings format update**, so please make sure your `lentosettings.json` file follows the updated specification. You can find an example of how the new settings look like in the `docs/example-settings.json` file.

**Dependencies changed:**
- Added `grabicon>=0.1.2` — makes it easier to get favicons for each site. I could roll my own version of this using `requests` and `BeautifulSoup4`, but due to time I think I'll leave that till `v1.0.0` or so.

**Non-ideal but non-dealbreakers:**
- Not much, I think this is a pretty solid PR :)